### PR TITLE
Ignore calls to SendSignalingMessage during destructor of Channel.

### DIFF
--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -127,10 +127,8 @@ P2PPeerConnectionChannel::P2PPeerConnectionChannel(
                                nullptr) {}
 
 P2PPeerConnectionChannel::~P2PPeerConnectionChannel() {
-  if (signaling_sender_) {
+  if (signaling_sender_)
     delete signaling_sender_;
-    signaling_sender_ = nullptr;
-  }
   ended_ = true;
   ClosePeerConnection();
 }
@@ -306,7 +304,7 @@ void P2PPeerConnectionChannel::SendSignalingMessage(
     const Json::Value& data,
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
-  if (signaling_sender_ == nullptr)
+  if (ended_) // signaling_sender_ has been deleted
     return;
   RTC_CHECK(signaling_sender_);
   std::string json_string = rtc::JsonValueToString(data);

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -127,8 +127,10 @@ P2PPeerConnectionChannel::P2PPeerConnectionChannel(
                                nullptr) {}
 
 P2PPeerConnectionChannel::~P2PPeerConnectionChannel() {
-  if (signaling_sender_)
+  if (signaling_sender_) {
     delete signaling_sender_;
+    signaling_sender_ = nullptr;
+  }
   ended_ = true;
   ClosePeerConnection();
 }
@@ -304,6 +306,8 @@ void P2PPeerConnectionChannel::SendSignalingMessage(
     const Json::Value& data,
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  if (signaling_sender_ == nullptr)
+    return;
   RTC_CHECK(signaling_sender_);
   std::string json_string = rtc::JsonValueToString(data);
   signaling_sender_->SendSignalingMessage(


### PR DESCRIPTION
The destructor of P2PPeerConnectionChannel calls ClosePeerConnection, which can end up attempting to SendSignalingMessage, after the signaling_sender_ object has been freed in the destructor. After freeing, set to null and skip any further signals.