### PR TITLE
Stable, synchronous closing of peer connections.

### DIFF
--- a/talk/owt/sdk/base/peerconnectionchannel.cc
+++ b/talk/owt/sdk/base/peerconnectionchannel.cc
@@ -16,8 +16,9 @@ PeerConnectionChannel::PeerConnectionChannel(
       factory_(nullptr) {}
 
 PeerConnectionChannel::~PeerConnectionChannel() {
-  if (peer_connection_ != nullptr) {
+  if (peer_connection_) {
     peer_connection_->Close();
+    peer_connection_ = nullptr;
   }
 }
 bool PeerConnectionChannel::InitializePeerConnection() {

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -377,11 +377,8 @@ void P2PClient::OnMessageReceived(const std::string& remote_id,
                          remote_id, message);
 }
 void P2PClient::OnStopped(const std::string& remote_id) {
-  std::thread([this, remote_id] {
-    const std::lock_guard<std::mutex> lock(pc_channels_mutex_);
-    signaling_channel_->SendMessage("chat-closed", remote_id, nullptr, nullptr);
-    pc_channels_.erase(remote_id);
-  }).detach();
+  const std::lock_guard<std::mutex> lock(pc_channels_mutex_);
+  pc_channels_.erase(remote_id);
 }
 void P2PClient::OnStreamAdded(std::shared_ptr<RemoteStream> stream) {
   EventTrigger::OnEvent1(

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -304,8 +304,6 @@ void P2PPeerConnectionChannel::SendSignalingMessage(
     const Json::Value& data,
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
-  if (ended_)
-    return;
   RTC_CHECK(signaling_sender_);
   std::string json_string = rtc::JsonValueToString(data);
   signaling_sender_->SendSignalingMessage(
@@ -1144,6 +1142,9 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
   if (negotiation_needed) {
     OnNegotiationNeeded();
   }
+  latest_local_stream_ = nullptr;
+  latest_publish_success_callback_ = nullptr;
+  latest_publish_failure_callback_ = nullptr;
 }
 void P2PPeerConnectionChannel::SendStop(
     std::function<void()> on_success,


### PR DESCRIPTION
Fixing the deadlock in OnStopped revealed an underlying bug in OWT that was segfaulting whenever a connection was closed.
The OnStopped() method deletes the P2PPeerConnectionChannel, which is the PeerConnectionObserver. OnStopped() was called
by TriggerOnStopped(), which was called in the OnIceConnectionChange(kClosed) function. This meant that the Observer was
being deleted during the execution of peer_connection->Close(), instead of waiting until the Close() returned, when it's
safe to delete the observer. This means removing TriggerOnStopped() from the OnIceConnectionChange callback.

Additionally, the previous hack to "intercept" outgoing messages in OnStopped() is totally unneeded, as the SendStop() in
P2PPeerConnection::Stop() already sends such a message in the framework. This message will be the one intercepted, which
is when the AmbientPublication references to the Frame Generators are deleted.

The final change is reversing the ordering of SendStop() and ClosePeerConnection() in Stop(). In order for the SHM readers to
be released on the correct thread, the final reference to the streams must be inside the peer connection, not the AmbientPublication.
Therefore, SendStop() (deleting the Publication) is moved before ClosePeerConnection() (closing the peer connection, releasing the SHM readers)

Also, releasing references to latest_local_stream and latest_publish_[success|failure]_callback at end of DrainPendingStreams(). Should not require a new publish to "push out" a stream if its already hung up.