### PR TITLE
Keep removed pc_channel so destructor isn't called by own method.

### DIFF
--- a/talk/owt/sdk/base/peerconnectionchannel.cc
+++ b/talk/owt/sdk/base/peerconnectionchannel.cc
@@ -16,7 +16,7 @@ PeerConnectionChannel::PeerConnectionChannel(
       factory_(nullptr) {}
 
 PeerConnectionChannel::~PeerConnectionChannel() {
-  if (peer_connection_) {
+  if (peer_connection_ != nullptr) {
     peer_connection_->Close();
     peer_connection_ = nullptr;
   }

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -245,6 +245,8 @@ class P2PClient final
   std::unordered_map<std::string, std::shared_ptr<P2PPeerConnectionChannel>>
       pc_channels_;
   std::mutex pc_channels_mutex_;
+  std::shared_ptr<P2PPeerConnectionChannel> removed_pc_;
+  std::mutex removed_pc_mutex_;
   std::string local_id_;
   std::vector<std::reference_wrapper<P2PClientObserver>> observers_;
   P2PClientConfiguration configuration_;

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -207,7 +207,7 @@ class P2PClient final
   /** @cond */
   void SetLocalId(const std::string& local_id);
   /** @endcond */
-  void UpdateClientConfiguration(P2PClientConfiguration configuration);
+  void UpdateClientConfiguration(const P2PClientConfiguration& configuration);
  protected:
   // Implement P2PSignalingSenderInterface
   virtual void SendSignalingMessage(const std::string& message,

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -207,10 +207,7 @@ class P2PClient final
   /** @cond */
   void SetLocalId(const std::string& local_id);
   /** @endcond */
-  void UpdateClientConfiguration(P2PClientConfiguration configuration) {
-    const std::lock_guard<std::mutex> lock(pc_channels_mutex_);
-    configuration_ = configuration;
-  }
+  void UpdateClientConfiguration(P2PClientConfiguration configuration);
  protected:
   // Implement P2PSignalingSenderInterface
   virtual void SendSignalingMessage(const std::string& message,

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -208,7 +208,8 @@ class P2PClient final
   void SetLocalId(const std::string& local_id);
   /** @endcond */
   void UpdateClientConfiguration(P2PClientConfiguration configuration) {
-     configuration_ = configuration;
+    const std::lock_guard<std::mutex> lock(pc_channels_mutex_);
+    configuration_ = configuration;
   }
  protected:
   // Implement P2PSignalingSenderInterface

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -203,6 +203,10 @@ void P2PClient::GetConnectionStats(
 void P2PClient::SetLocalId(const std::string& local_id) {
   local_id_ = local_id;
 }
+void P2PClient::UpdateClientConfiguration(P2PClientConfiguration configuration) {
+  const std::lock_guard<std::mutex> lock(pc_channels_mutex_);
+  configuration_ = configuration;
+}
 void P2PClient::OnSignalingMessage(const std::string& message,
                                    const std::string& remote_id) {
   // First to check whether remote_id is in the allowed_remote_ids_ list.

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -377,6 +377,10 @@ void P2PClient::OnMessageReceived(const std::string& remote_id,
                          remote_id, message);
 }
 void P2PClient::OnStopped(const std::string& remote_id) {
+  {
+    const std::lock_guard<std::mutex> removed_lock(removed_pc_mutex_);
+    removed_pc_ = pc_channels_[remote_id];
+  }
   const std::lock_guard<std::mutex> lock(pc_channels_mutex_);
   pc_channels_.erase(remote_id);
 }

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -377,11 +377,10 @@ void P2PClient::OnMessageReceived(const std::string& remote_id,
                          remote_id, message);
 }
 void P2PClient::OnStopped(const std::string& remote_id) {
-  {
-    const std::lock_guard<std::mutex> removed_lock(removed_pc_mutex_);
-    removed_pc_ = pc_channels_[remote_id];
-  }
-  const std::lock_guard<std::mutex> lock(pc_channels_mutex_);
+  std::lock(removed_pc_mutex_, pc_channels_mutex_);
+  const std::lock_guard<std::mutex> lock1(removed_pc_mutex_, std::adopt_lock);
+  const std::lock_guard<std::mutex> lock2(pc_channels_mutex_, std::adopt_lock);
+  removed_pc_ = pc_channels_[remote_id];
   pc_channels_.erase(remote_id);
 }
 void P2PClient::OnStreamAdded(std::shared_ptr<RemoteStream> stream) {

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -203,7 +203,7 @@ void P2PClient::GetConnectionStats(
 void P2PClient::SetLocalId(const std::string& local_id) {
   local_id_ = local_id;
 }
-void P2PClient::UpdateClientConfiguration(P2PClientConfiguration configuration) {
+void P2PClient::UpdateClientConfiguration(const P2PClientConfiguration& configuration) {
   const std::lock_guard<std::mutex> lock(pc_channels_mutex_);
   configuration_ = configuration;
 }
@@ -380,10 +380,11 @@ void P2PClient::OnMessageReceived(const std::string& remote_id,
                          &P2PClientObserver::OnMessageReceived,
                          remote_id, message);
 }
+// Does not remove final reference to channel until the next channel stops, so connections
+// are fully closed and all methods return before cleanup.
 void P2PClient::OnStopped(const std::string& remote_id) {
-  std::lock(removed_pc_mutex_, pc_channels_mutex_);
-  const std::lock_guard<std::mutex> lock1(removed_pc_mutex_, std::adopt_lock);
-  const std::lock_guard<std::mutex> lock2(pc_channels_mutex_, std::adopt_lock);
+  const std::lock_guard<std::mutex> lock1(removed_pc_mutex_);
+  const std::lock_guard<std::mutex> lock2(pc_channels_mutex_);
   removed_pc_ = pc_channels_[remote_id];
   pc_channels_.erase(remote_id);
 }


### PR DESCRIPTION
Undid other changes to base OWT framework. So now, only changes to base framework are:
1. Setting latest_*_ pointers to nullptr in DrainPendingStreams, so modal clients are immediately released without needing a new Publish to "push" out the reference. Moved where in the method it was called to be in the lock-guarded section clearing the pending_publish_streams.
2. Instead of an unbounded vector, the OnStopped() method overwrites a single shared_ptr (effectively, a vector of size 1). Testing confirmed that even before the channel is fully deleted, all SHM clients are released when the streams are stopped and the publication_map entries are cleared (by the SendStop() -> SendSignalingMessage() -> onDisconnected() code path)
3. Small hanges external to this PR to allow compilation when not using Audio (not intended for inclusion in the base PR, not significant to keep)

