### PR TITLE
All callbacks are synchronous, using extra ref to avoid deadlock.

### DIFF
--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -247,7 +247,6 @@ class P2PClient final
       pc_channels_;
   std::mutex pc_channels_mutex_;
   std::shared_ptr<P2PPeerConnectionChannel> removed_pc_;
-  std::mutex removed_pc_mutex_;
   std::string local_id_;
   std::vector<std::reference_wrapper<P2PClientObserver>> observers_;
   P2PClientConfiguration configuration_;

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -86,11 +86,11 @@ void P2PClient::RemoveAllowedRemoteId(const std::string& target_id,
       }
       return;
     }
-    for (auto it = allowed_remote_ids_.begin(), it != allowed_remote_ids_.end();) {
+    for (auto it = allowed_remote_ids_.begin(); it != allowed_remote_ids_.end();) {
       if (*it == target_id) {
         allowed_remote_ids_.erase(it);
       } else {
-        it++;
+        ++it;
       }
     }
   }
@@ -400,11 +400,11 @@ void P2PClient::OnStopped(const std::string& remote_id) {
   // remove from allowed ids to prevent memory leaks.
   {
     const std::lock_guard<std::mutex> lock(remote_ids_mutex_);
-    for (auto it = allowed_remote_ids_.begin(), it != allowed_remote_ids_.end();) {
+    for (auto it = allowed_remote_ids_.begin(); it != allowed_remote_ids_.end();) {
       if (*it == remote_id) {
         allowed_remote_ids_.erase(it);
       } else {
-        it++;
+        ++it;
       }
     }
   }

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -88,18 +88,22 @@ void P2PClient::Publish(
     std::function<void(std::shared_ptr<P2PPublication>)> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   // Firstly check whether target_id is in the allowed_remote_ids_ list.
-  if (std::find(allowed_remote_ids_.begin(), allowed_remote_ids_.end(), target_id) ==
-      allowed_remote_ids_.end()) {
+  bool not_allowed = false;
+  {
+    const std::lock_guard<std::mutex> lock(remote_ids_mutex_);
+    not_allowed = (std::find(allowed_remote_ids_.begin(), allowed_remote_ids_.end(), target_id) ==
+      allowed_remote_ids_.end());
+  }
+  if (not_allowed) {
     if (on_failure) {
-      event_queue_->PostTask([on_failure] {
-        std::unique_ptr<Exception> e(
-            new Exception(ExceptionType::kP2PClientRemoteNotAllowed,
-                          "Publishing a stream cannot be done since the remote user is not allowed."));
-        on_failure(std::move(e));
-      });
+      std::unique_ptr<Exception> e(
+        new Exception(ExceptionType::kP2PClientRemoteNotAllowed,
+         "Publishing a stream cannot be done since the remote user is not allowed."));
+      on_failure(std::move(e));
     }
     return;
   }
+
   // Secondly use pcc to publish the stream.
   auto pcc = GetPeerConnectionChannel(target_id);
   std::weak_ptr<P2PClient> weak_this = shared_from_this();
@@ -110,7 +114,8 @@ void P2PClient::Publish(
     if (!that)
       return;
     std::shared_ptr<P2PPublication> publication(new P2PPublication(that, target_id, stream));
-    that->event_queue_->PostTask([on_success, publication] {on_success(publication); });
+    on_success(publication);
+    //that->event_queue_->PostTask([on_success, publication] {on_success(publication); });
   }, on_failure);
 }
 void P2PClient::Send(
@@ -119,15 +124,18 @@ void P2PClient::Send(
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   // Firstly check whether target_id is in the allowed_remote_ids_ list.
-  if (std::find(allowed_remote_ids_.begin(), allowed_remote_ids_.end(), target_id) ==
-      allowed_remote_ids_.end()) {
+  bool not_allowed = false;
+  {
+    const std::lock_guard<std::mutex> lock(remote_ids_mutex_);
+    not_allowed = (std::find(allowed_remote_ids_.begin(), allowed_remote_ids_.end(), target_id) ==
+      allowed_remote_ids_.end());
+  }
+  if (not_allowed) {
     if (on_failure) {
-      event_queue_->PostTask([on_failure] {
-        std::unique_ptr<Exception> e(
-            new Exception(ExceptionType::kP2PClientRemoteNotAllowed,
-                          "Sending a message cannot be done since the remote user is not allowed."));
-        on_failure(std::move(e));
-      });
+      std::unique_ptr<Exception> e(
+          new Exception(ExceptionType::kP2PClientRemoteNotAllowed,
+                        "Sending a message cannot be done since the remote user is not allowed."));
+      on_failure(std::move(e));
     }
     return;
   }
@@ -141,19 +149,15 @@ void P2PClient::Stop(
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   if (!IsPeerConnectionChannelCreated(target_id)) {
     if (on_failure) {
-      event_queue_->PostTask([on_failure] {
-        std::unique_ptr<Exception> e(
-          new Exception(ExceptionType::kP2PClientInvalidState,
-            "Non-existed chat need not be stopped."));
-        on_failure(std::move(e));
-      });
+      std::unique_ptr<Exception> e(
+        new Exception(ExceptionType::kP2PClientInvalidState,
+          "Non-existed chat need not be stopped."));
+      on_failure(std::move(e));
     }
     return;
   }
   auto pcc = GetPeerConnectionChannel(target_id);
   pcc->Stop(on_success, on_failure);
-  const std::lock_guard<std::mutex> lock(pc_channels_mutex_);
-  pc_channels_.erase(target_id);
 }
 void P2PClient::GetConnectionStats(
     const std::string& target_id,
@@ -161,12 +165,10 @@ void P2PClient::GetConnectionStats(
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   if (!IsPeerConnectionChannelCreated(target_id)) {
     if (on_failure) {
-      event_queue_->PostTask([on_failure] {
-        std::unique_ptr<Exception> e(
-          new Exception(ExceptionType::kP2PClientInvalidState,
-            "Non-existed peer connection cannot provide stats."));
-        on_failure(std::move(e));
-      });
+      std::unique_ptr<Exception> e(
+        new Exception(ExceptionType::kP2PClientInvalidState,
+          "Non-existed peer connection cannot provide stats."));
+      on_failure(std::move(e));
     }
     return;
   }
@@ -180,12 +182,10 @@ void P2PClient::GetConnectionStats(
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   if (!IsPeerConnectionChannelCreated(target_id)) {
     if (on_failure) {
-      event_queue_->PostTask([on_failure] {
-        std::unique_ptr<Exception> e(
-            new Exception(ExceptionType::kP2PClientInvalidState,
-                          "Non-existed peer connection cannot provide stats."));
-        on_failure(std::move(e));
-      });
+      std::unique_ptr<Exception> e(
+          new Exception(ExceptionType::kP2PClientInvalidState,
+                        "Non-existed peer connection cannot provide stats."));
+      on_failure(std::move(e));
     }
     return;
   }
@@ -203,8 +203,13 @@ void P2PClient::UpdateClientConfiguration(const P2PClientConfiguration& configur
 void P2PClient::OnSignalingMessage(const std::string& message,
                                    const std::string& remote_id) {
   // First to check whether remote_id is in the allowed_remote_ids_ list.
-  if (std::find(allowed_remote_ids_.begin(), allowed_remote_ids_.end(), remote_id) ==
-      allowed_remote_ids_.end()) {
+  bool not_allowed = false;
+  {
+    const std::lock_guard<std::mutex> lock(remote_ids_mutex_);
+    not_allowed = (std::find(allowed_remote_ids_.begin(), allowed_remote_ids_.end(), remote_id) ==
+        allowed_remote_ids_.end());
+  }
+  if (not_allowed) {
     RTC_LOG(LS_WARNING) << "Chat cannot be setup since the remote user is not allowed.";
     return;
   }
@@ -313,6 +318,7 @@ std::shared_ptr<P2PPeerConnectionChannel> P2PClient::GetPeerConnectionChannel(
   auto pcc_it = pc_channels_.find(target_id);
   // if the channel has already been abandoned
   if (pcc_it != pc_channels_.end() && pcc_it->second->IsAbandoned()) {
+    removed_pc_ = pc_channels_[target_id];
     pc_channels_.erase(target_id);
     pcc_it = pc_channels_.end();
   }
@@ -377,8 +383,7 @@ void P2PClient::OnMessageReceived(const std::string& remote_id,
 // are fully closed and all methods return before cleanup.
 void P2PClient::OnStopped(const std::string& remote_id) {
   {
-    const std::lock_guard<std::mutex> lock1(removed_pc_mutex_);
-    const std::lock_guard<std::mutex> lock2(pc_channels_mutex_);
+    const std::lock_guard<std::mutex> lock(pc_channels_mutex_);
     auto it = pc_channels_.find(remote_id);
     if (it != pc_channels_.end()) {
       removed_pc_ = pc_channels_[remote_id];

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -86,9 +86,13 @@ void P2PClient::RemoveAllowedRemoteId(const std::string& target_id,
       }
       return;
     }
-    allowed_remote_ids_.erase(
-        std::remove(allowed_remote_ids_.begin(), allowed_remote_ids_.end(), target_id),
-        allowed_remote_ids_.end());
+    for (auto it = allowed_remote_ids_.begin(), it != allowed_remote_ids_.end();) {
+      if (*it == target_id) {
+        allowed_remote_ids_.erase(it);
+      } else {
+        it++;
+      }
+    }
   }
   Stop(target_id, on_success, on_failure);
 }
@@ -396,9 +400,13 @@ void P2PClient::OnStopped(const std::string& remote_id) {
   // remove from allowed ids to prevent memory leaks.
   {
     const std::lock_guard<std::mutex> lock(remote_ids_mutex_);
-    allowed_remote_ids_.erase(
-        std::remove(allowed_remote_ids_.begin(), allowed_remote_ids_.end(), remote_id),
-        allowed_remote_ids_.end());
+    for (auto it = allowed_remote_ids_.begin(), it != allowed_remote_ids_.end();) {
+      if (*it == remote_id) {
+        allowed_remote_ids_.erase(it);
+      } else {
+        it++;
+      }
+    }
   }
 }
 void P2PClient::OnStreamAdded(std::shared_ptr<RemoteStream> stream) {

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1178,6 +1178,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
             break;
           }
         }
+
       }
       for (const auto& track : media_stream->GetVideoTracks()) {
         const auto& senders = temp_pc_->GetSenders();
@@ -1353,10 +1354,10 @@ void P2PPeerConnectionChannel::HandleRemoteCapability(Json::Value& ua) {
   rtc::GetBoolFromJsonObject(capabilities, kUaUnifiedPlanKey,
                              &remote_side_supports_unified_plan_);
   remote_side_supports_plan_b_ = !remote_side_supports_unified_plan_;
-  rtc::GetBoolFromJsonObject(capabilities, kUaStreamRemovableKey,
-                             &remote_side_supports_remove_stream_);
+  // Firefox is now on unified plan semantics, so supports removing streams.
   rtc::GetBoolFromJsonObject(capabilities, kUaIgnoresDataChannelAcksKey,
                              &remote_side_ignores_datachannel_acks_);
+  remote_side_supports_remove_stream_ = true;
   RTC_LOG(LS_INFO) << "Remote side supports removing stream? "
                    << remote_side_supports_remove_stream_;
   RTC_LOG(LS_INFO) << "Remote side supports WebRTC Plan B? "

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -122,6 +122,7 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   virtual void OnIceGatheringChange(
       PeerConnectionInterface::IceGatheringState new_state) override;
   virtual void OnIceCandidate(const webrtc::IceCandidateInterface* candidate) override;
+  virtual void OnRenegotiationNeeded() override;
   // DataChannelObserver
   virtual void OnDataChannelStateChange() override;
   virtual void OnDataChannelMessage(const webrtc::DataBuffer& buffer) override;

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -39,7 +39,8 @@ class P2PPeerConnectionChannelObserver {
 // An instance of P2PPeerConnectionChannel manages a session for a specified
 // remote client.
 class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
-                                 public PeerConnectionChannel {
+                                 public PeerConnectionChannel,
+                                 public std::enable_shared_from_this<P2PPeerConnectionChannel> {
  public:
   explicit P2PPeerConnectionChannel(
       PeerConnectionChannelConfiguration configuration,
@@ -201,6 +202,7 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   std::unordered_map<std::string, std::function<void()>> publish_success_callbacks_;
   // Store remote SDP if it cannot be set currently.
   std::unique_ptr<webrtc::SessionDescriptionInterface> pending_remote_sdp_;
+  std::mutex last_disconnect_mutex_;
   std::chrono::time_point<std::chrono::system_clock>
       last_disconnect_;  // Last time |peer_connection_| changes its state to
                          // "disconnect".
@@ -236,6 +238,7 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   std::function<void()> latest_publish_success_callback_;
   std::function<void(std::unique_ptr<Exception>)> latest_publish_failure_callback_;
   bool ua_sent_;
+  std::mutex stop_send_mutex_;
   bool stop_send_needed_;
   bool remote_side_offline_;
   bool ended_;

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -233,8 +233,6 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   std::mutex is_creating_offer_mutex_;
   // Queue for callbacks and events.
   std::shared_ptr<rtc::TaskQueue> event_queue_;
-  std::mutex failure_callbacks_mutex_;
-  std::unordered_map<std::string, std::function<void(std::unique_ptr<Exception>)>> failure_callbacks_;
   std::shared_ptr<LocalStream> latest_local_stream_;
   std::function<void()> latest_publish_success_callback_;
   std::function<void(std::unique_ptr<Exception>)> latest_publish_failure_callback_;

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -147,6 +147,8 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   void CheckWaitedList();  // Check pending streams and negotiation requests.
   void SendStop(std::function<void()> on_success,
                 std::function<void(std::unique_ptr<Exception>)> on_failure);
+  // Returns a new reference, so lifetime of connection lasts at least until end of caller.
+  rtc::scoped_refptr<webrtc::PeerConnectionInterface> GetPeerConnectionRef();
   void ClosePeerConnection();  // Stop session and clean up.
   // Returns true if |pointer| is not nullptr. Otherwise, return false and
   // execute |on_failure|.
@@ -211,6 +213,8 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
       pending_messages_;
   // Protects |pending_messages_|.
   std::mutex pending_messages_mutex_;
+  // Protects |ended_|
+  std::mutex ended_mutex_;
   // Indicates whether remote client supports WebRTC Plan B
   // (https://tools.ietf.org/html/draft-uberti-rtcweb-plan-00).
   // If plan B is not supported, at most one audio/video track is supported.


### PR DESCRIPTION
This comment isolates the layers of OWT from WebRTC. The only operation called inside a lock is Close(), which is called while holding the ended_mutex_, which calls OnIceConnectionChange(kClosed) and OnSignalingChange(kClosed).

In both of these callbacks, the ended_mutex_ lock is not acquired, preventing deadlock.
All other webrtc::PeerConnectionInterface operations are done without holding a lock, by first acquiring a reference while holding the ended_mutex_ lock. Then, after releasing the lock, the reference ensures the peer_connection has at least 1 refcount until the end of the function calling the operation.

On_success and on_failure callbacks in the channel are synchronous, as the event_queue_ outlives the channel itself.

Review this while doing a comprehensive graph-analysis to prove completeness.