### PR TITLE
P2PClient destructor - remove from observers

### DIFF
--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -74,6 +74,9 @@ class P2PClient final
    */
   P2PClient(P2PClientConfiguration& configuration,
             std::shared_ptr<P2PSignalingChannelInterface> signaling_channel);
+
+  ~P2PClient();
+
   /*! Add an observer for peer client.
    @param observer Add this object to observer list.
           Do not delete this object until it is removed from observer list.

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -34,6 +34,9 @@ P2PClient::P2PClient(
       std::make_unique<rtc::TaskQueue>(task_queue_factory->CreateTaskQueue(
           "P2PClientEventQueue", webrtc::TaskQueueFactory::Priority::NORMAL));
 }
+P2PClient::~P2PClient() {
+  signaling_channel_->RemoveObserver(*this);
+}
 void P2PClient::Connect(
     const std::string& host,
     const std::string& token,


### PR DESCRIPTION
This allows running the webrtc_server properly through valgrind 