### PR TITLE
Fix race on last_disconnect_ and SendStop() in destructor.

### DIFF
--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -318,7 +318,6 @@ std::shared_ptr<P2PPeerConnectionChannel> P2PClient::GetPeerConnectionChannel(
   auto pcc_it = pc_channels_.find(target_id);
   // if the channel has already been abandoned
   if (pcc_it != pc_channels_.end() && pcc_it->second->IsAbandoned()) {
-    removed_pc_ = pc_channels_[target_id];
     pc_channels_.erase(target_id);
     pcc_it = pc_channels_.end();
   }

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -127,8 +127,10 @@ P2PPeerConnectionChannel::P2PPeerConnectionChannel(
                                nullptr) {}
 
 P2PPeerConnectionChannel::~P2PPeerConnectionChannel() {
-  if (signaling_sender_)
+  if (signaling_sender) {
+    SendStop(nullptr, nullptr);
     delete signaling_sender_;
+  }
   if (peer_connection_ != nullptr) {
     peer_connection_->Close();
   }
@@ -817,7 +819,10 @@ void P2PPeerConnectionChannel::TriggerOnStopped() {
 void P2PPeerConnectionChannel::CleanLastPeerConnection() {
   pending_remote_sdp_.reset();
   negotiation_needed_ = false;
-  last_disconnect_ = std::chrono::time_point<std::chrono::system_clock>::max();
+  {
+    std::lock_guard<std::mutex> lock(last_disconnect_mutex_);
+    last_disconnect_ = std::chrono::time_point<std::chrono::system_clock>::max();
+  }
 }
 void P2PPeerConnectionChannel::Unpublish(
     std::shared_ptr<LocalStream> stream,


### PR DESCRIPTION
SendStop() is what triggers onDisconnected(), so the destructor of the channel will cleanup the Publications. This is technically redundant in the normal flow, but this will prevent any leaks in the Ambient Layer (since by definition the references aren't in the P2P layer once destroyed.)