### PR TITLE
TriggerOnStopped() should be synchronous, OnStopped() is asynchronous.

### DIFF
--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -799,12 +799,10 @@ bool P2PPeerConnectionChannel::CheckNullPointer(
 }
 
 void P2PPeerConnectionChannel::TriggerOnStopped() {
-  event_queue_->PostTask([this]() {
-    for (std::vector<P2PPeerConnectionChannelObserver*>::iterator it =
-         observers_.begin(); it != observers_.end(); it++) {
-      (*it)->OnStopped(remote_id_);
-    }
-  });
+  for (std::vector<P2PPeerConnectionChannelObserver*>::iterator it =
+       observers_.begin(); it != observers_.end(); it++) {
+    (*it)->OnStopped(remote_id_);
+  }
 }
 
 void P2PPeerConnectionChannel::CleanLastPeerConnection() {


### PR DESCRIPTION
Shouldn't have been posted before anyways in case the channel died (along with observers_) before the OnStopped() could run.