### PR TITLE
Store remote candidates in a queue

### DIFF
--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -491,6 +491,17 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
     webrtc::IceCandidateInterface* ice_candidate = webrtc::CreateIceCandidate(
         sdp_mid, sdp_mline_index, candidate, nullptr);
     temp_pc_->AddIceCandidate(ice_candidate);
+    if(temp_pc_->remote_description()){
+      if (!temp_pc_->AddIceCandidate(ice_candidate)) {
+        RTC_LOG(LS_WARNING) << "Failed to add remote candidate.";
+      }
+    } else{
+      rtc::CritScope cs(&pending_remote_candidates_crit_);
+      pending_remote_candidates_.push_back(
+          std::unique_ptr<webrtc::IceCandidateInterface>(ice_candidate));
+      RTC_LOG(LS_VERBOSE) << "Remote candidate is stored because remote "
+                             "session description is missing.";
+    }
   }
 }
 void P2PPeerConnectionChannel::OnMessageTracksAdded(
@@ -540,7 +551,7 @@ void P2PPeerConnectionChannel::OnSignalingChange(
   switch (new_state) {
     case PeerConnectionInterface::SignalingState::kStable:
       if (pending_remote_sdp_) {
-	RTC_LOG(LS_INFO) << "Retrying SetRemoteDescription from kStable state";
+	    RTC_LOG(LS_INFO) << "Retrying SetRemoteDescription from kStable state";
         scoped_refptr<FunctionalSetRemoteDescriptionObserver> observer =
             FunctionalSetRemoteDescriptionObserver::Create(std::bind(
                 &P2PPeerConnectionChannel::OnSetRemoteDescriptionComplete, this,
@@ -568,6 +579,10 @@ void P2PPeerConnectionChannel::OnSignalingChange(
       } else {
         DrainPendingStreams();
       }
+      DrainPendingRemoteCandidates();
+      break;
+    case PeerConnectionInterface::SignalingState::kHaveRemoteOffer:
+      DrainPendingRemoteCandidates();
       break;
     default:
       break;
@@ -1180,6 +1195,10 @@ void P2PPeerConnectionChannel::ClosePeerConnection() {
       std::lock_guard<std::mutex> lock(pending_publish_streams_mutex_);
       pending_publish_streams_.clear();
     }
+    {
+      rtc::CritScope cs(&pending_remote_candidates_crit_);
+      pending_remote_candidates_.clear();
+    }
     TriggerOnStopped();
   }
 }
@@ -1273,6 +1292,18 @@ void P2PPeerConnectionChannel::DrainPendingMessages() {
     for (const auto& msg : messages_snapshot) {
       temp_dc_->Send(CreateDataBuffer(msg));
     }
+  }
+}
+void P2PPeerConnectionChannel::DrainPendingRemoteCandidates() {
+  rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
+  {
+    rtc::CritScope cs(&pending_remote_candidates_crit_);
+    for (auto& ice_candidate : pending_remote_candidates_) {
+      if (!temp_pc_->AddIceCandidate(ice_candidate.get())) {
+        RTC_LOG(LS_WARNING) << "Failed to add remote candidate.";
+      }
+    }
+    pending_remote_candidates_.clear();
   }
 }
 Json::Value P2PPeerConnectionChannel::UaInfo() {

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -490,7 +490,6 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
                             &sdp_mline_index);
     webrtc::IceCandidateInterface* ice_candidate = webrtc::CreateIceCandidate(
         sdp_mid, sdp_mline_index, candidate, nullptr);
-    temp_pc_->AddIceCandidate(ice_candidate);
     if(temp_pc_->remote_description()){
       if (!temp_pc_->AddIceCandidate(ice_candidate)) {
         RTC_LOG(LS_WARNING) << "Failed to add remote candidate.";

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -550,7 +550,7 @@ void P2PPeerConnectionChannel::OnSignalingChange(
   switch (new_state) {
     case PeerConnectionInterface::SignalingState::kStable:
       if (pending_remote_sdp_) {
-	    RTC_LOG(LS_INFO) << "Retrying SetRemoteDescription from kStable state";
+        RTC_LOG(LS_INFO) << "Retrying SetRemoteDescription from kStable state";
         scoped_refptr<FunctionalSetRemoteDescriptionObserver> observer =
             FunctionalSetRemoteDescriptionObserver::Create(std::bind(
                 &P2PPeerConnectionChannel::OnSetRemoteDescriptionComplete, this,

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -162,6 +162,8 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   void CreateDataChannel(const std::string& label);
   // Send all messages in pending message list.
   void DrainPendingMessages();
+  // Process any waiting ICE Candidates
+  void DrainPendingRemoteCandidates();
   // Cleans all variables associated with last peerconnection.
   void CleanLastPeerConnection();
   // Returns user agent info as JSON object.
@@ -216,6 +218,10 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   std::mutex pending_messages_mutex_;
   // Protects |ended_|
   std::mutex ended_mutex_;
+  // Hold incoming ICE candidates if remote session description not yet processed.
+  rtc::CriticalSection pending_remote_candidates_crit_;
+  std::vector<std::unique_ptr<webrtc::IceCandidateInterface>>
+      pending_remote_candidates_ RTC_GUARDED_BY(pending_remote_candidates_crit_);
   // Indicates whether remote client supports WebRTC Plan B
   // (https://tools.ietf.org/html/draft-uberti-rtcweb-plan-00).
   // If plan B is not supported, at most one audio/video track is supported.


### PR DESCRIPTION
Hold until remote candidate arrives. Clears if connection closes.  