### PR TITLE
Fix for growing Offer/Answers

### DIFF
--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1135,22 +1135,23 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
           stream->MediaStream();
       RTC_CHECK(temp_pc_);
       for (const auto& track : media_stream->GetAudioTracks()) {
-        const auto& senders = temp_pc_->GetSenders();
-        for (auto& s : senders) {
-          const auto& t = s->track();
-          if (t != nullptr && t->id() == track->id()) {
-            temp_pc_->RemoveTrack(s);
+        const auto& transceivers = temp_pc_->GetTransceivers();
+        for (auto& transceiver : transceivers) {
+          const auto& ttrack = transceiver->sender()->track();
+          if (ttrack != nullptr && ttrack->id() == track->id()) {
+            transceiver->Stop();
+            temp_pc_->RemoveTrackNew(transceiver->sender());
             break;
           }
         }
-
       }
       for (const auto& track : media_stream->GetVideoTracks()) {
-        const auto& senders = temp_pc_->GetSenders();
-        for (auto& s : senders) {
-          const auto& t = s->track();
-          if (t != nullptr && t->id() == track->id()) {
-            temp_pc_->RemoveTrack(s);
+        const auto& transceivers = temp_pc_->GetTransceivers();
+        for (auto& transceiver : transceivers) {
+          const auto& ttrack = transceiver->sender()->track();
+          if (ttrack != nullptr && ttrack->id() == track->id()) {
+            transceiver->Stop();
+            temp_pc_->RemoveTrackNew(transceiver->sender());
             break;
           }
         }


### PR DESCRIPTION
In webrtc's unified-plan semantics, instead of adding tracks to streams, you
operate mostly in transceivers. When hanging up a stream, the transceiver
should be Stopped and the track removed with the RemoveTrackNew() method, which
should be used over the plan-b RemoveTrack() method.

With this change, we no longer need to force a PeerConnection reset, and it should
also improve stream latencies.

Testing locally confirms that after hanging up a stream, the transceivers are
now being stopped, and no longer included in Offer/Answers. Additionally,
previously stopped Transceivers can be used for new streams.

Previously, when switching between RAW and SPE modes, the SDP offer showed the following MIDs
1 5 6 7 (1 is the data channel, 5, 6, 7 are the streams) then 1 5 6 7 11 12 13, even though only 3 streams are playing at once.

Now, the switch goes from
1 5 6 7 to 1 11 12 13