### PR TITLE
Must call RemoveTrack before calling Stop

### DIFF
--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1139,8 +1139,8 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
         for (auto& transceiver : transceivers) {
           const auto& ttrack = transceiver->sender()->track();
           if (ttrack != nullptr && ttrack->id() == track->id()) {
+            temp_pc_->RemoveTrack(transceiver->sender());
             transceiver->Stop();
-            temp_pc_->RemoveTrackNew(transceiver->sender());
             break;
           }
         }
@@ -1150,8 +1150,8 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
         for (auto& transceiver : transceivers) {
           const auto& ttrack = transceiver->sender()->track();
           if (ttrack != nullptr && ttrack->id() == track->id()) {
+            temp_pc_->RemoveTrack(transceiver->sender());
             transceiver->Stop();
-            temp_pc_->RemoveTrackNew(transceiver->sender());
             break;
           }
         }


### PR DESCRIPTION
Switching these two lines completely fixes the leaking indices from get_audit.
In the base webrtc layer, RemoveTrack() calls RemoveTrackNew(), and RemoveTrack is the actual specification, so will call that, which triggers all the callbacks for cleaning up P2PPublication, then call Stop() on the transceiver to keep the SDP small.

Tested with local product without a peer connection reset mechanism and opened streams while switching modes and opening/closing modals. All runs of get_audit pass.

Opening multiple tabs and closing them also passes get_audit, though there's a delay in cleaning up streams to tabs just recently closed. This is at parity with previous behavior, and will follow up with this in a separate PR.