### PR TITLE
Fix null pointer exception in DrainPendingRemoteCandidates

### DIFF
--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1296,7 +1296,9 @@ void P2PPeerConnectionChannel::DrainPendingMessages() {
 }
 void P2PPeerConnectionChannel::DrainPendingRemoteCandidates() {
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
-  {
+  // If we didn't get a connection ref, that means that the connection already got closed
+  // and pending remote candidates have already been cleared.
+  if (temp_pc_) {
     rtc::CritScope cs(&pending_remote_candidates_crit_);
     if (temp_pc_->remote_description()) {
       RTC_LOG(LS_INFO) << "Draining pending ICE Candidates, received " << pending_remote_candidates_.size();

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -546,6 +546,10 @@ void P2PPeerConnectionChannel::OnMessageStreamInfo(Json::Value& stream_info) {
 void P2PPeerConnectionChannel::OnSignalingChange(
     PeerConnectionInterface::SignalingState new_state) {
   RTC_LOG(LS_INFO) << "Signaling state changed: " << new_state;
+  // TODO @sam: We probably want to keep the peer_connection_ alive for this method,
+  // like the other methods that need the peer_connection_.
+  // Investigate uncommenting the below.
+  // rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   switch (new_state) {
     case PeerConnectionInterface::SignalingState::kStable:
       if (pending_remote_sdp_) {

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -546,7 +546,6 @@ void P2PPeerConnectionChannel::OnMessageStreamInfo(Json::Value& stream_info) {
 void P2PPeerConnectionChannel::OnSignalingChange(
     PeerConnectionInterface::SignalingState new_state) {
   RTC_LOG(LS_INFO) << "Signaling state changed: " << new_state;
-  rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_;
   switch (new_state) {
     case PeerConnectionInterface::SignalingState::kStable:
       if (pending_remote_sdp_) {
@@ -1298,17 +1297,15 @@ void P2PPeerConnectionChannel::DrainPendingRemoteCandidates() {
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   // If we didn't get a connection ref, that means that the connection already got closed
   // and pending remote candidates have already been cleared.
-  if (temp_pc_) {
+  if (temp_pc_ && temp_pc_->remote_description()) {
     rtc::CritScope cs(&pending_remote_candidates_crit_);
-    if (temp_pc_->remote_description()) {
-      RTC_LOG(LS_INFO) << "Draining pending ICE Candidates, received " << pending_remote_candidates_.size();
-      for (const auto& ice_candidate : pending_remote_candidates_) {
-        if (!temp_pc_->AddIceCandidate(ice_candidate.get())) {
-          RTC_LOG(LS_WARNING) << "Failed to add remote candidate.";
-        }
+    RTC_LOG(LS_INFO) << "Draining pending ICE Candidates, received " << pending_remote_candidates_.size();
+    for (const auto& ice_candidate : pending_remote_candidates_) {
+      if (!temp_pc_->AddIceCandidate(ice_candidate.get())) {
+        RTC_LOG(LS_WARNING) << "Failed to add remote candidate.";
       }
-      pending_remote_candidates_.clear();
     }
+    pending_remote_candidates_.clear();
   }
 }
 Json::Value P2PPeerConnectionChannel::UaInfo() {


### PR DESCRIPTION
Hoping to fix this crash that I saw in production:
```
Stack trace (most recent call last) in thread 3283398:
#19   Source "../sysdeps/unix/sysv/linux/x86_64/clone.S", line 95, in __clone [0x7f533e0f9132]
#18   Source "/build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c", line 477, in start_thread [0x7f533eb68608]
#17   Source "../../third_party/webrtc/rtc_base/thread.cc", line 831, in rtc::Thread::PreRun(void*) [0x556083bf76c9]
#16   Source "../../third_party/webrtc/rtc_base/thread.cc", line 842, in rtc::Thread::Run() [0x556083bf7714]
#15   Source "../../third_party/webrtc/rtc_base/thread.cc", line 1000, in rtc::Thread::ProcessMessages(int) [0x556083bf82b9]
#14   Source "../../third_party/webrtc/rtc_base/thread.cc", line 664, in rtc::Thread::Dispatch(rtc::Message*) [0x556083bf663d]
#13   Source "../../third_party/webrtc/api/proxy.cc", line 32, in webrtc::internal::SynchronousMethodCall::OnMessage(rtc::Message*) [0x556084404253]
#12   Source "../../third_party/webrtc/api/proxy.h", line 132, in webrtc::MethodCall<webrtc::PeerConnectionInterface, void, std::unique_ptr<webrtc::Ses
sionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >, rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface>
 >::OnMessage(rtc::Message*) [0x55608416c79e]
#11   Source "../../third_party/webrtc/api/proxy.h", line 136, in void webrtc::MethodCall<webrtc::PeerConnectionInterface, void, std::unique_ptr<webrtc
::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >, rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInter
face> >::Invoke<0ul, 1ul>(std::integer_sequence<unsigned long, 0ul, 1ul>) [0x55608416d6ae]
#10   Source "../../third_party/webrtc/api/proxy.h", line 92, in void webrtc::ReturnType<void>::Invoke<webrtc::PeerConnectionInterface, void (webrtc::P
eerConnectionInterface::*)(std::unique_ptr<webrtc::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >, rtc::scoped
_refptr<webrtc::SetRemoteDescriptionObserverInterface>), std::unique_ptr<webrtc::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescri
ptionInterface> >, rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface> >(webrtc::PeerConnectionInterface*, void (webrtc::PeerConnectionIn
terface::*)(std::unique_ptr<webrtc::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >, rtc::scoped_refptr<webrtc:
:SetRemoteDescriptionObserverInterface>), std::unique_ptr<webrtc::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface>
 >&&, rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface>&&) [0x55608416fca8]
#9    Source "../../third_party/webrtc/pc/peer_connection.cc", line 2964, in webrtc::PeerConnection::SetRemoteDescription(std::unique_ptr<webrtc::Sessi
onDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >, rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface>) 
[0x5560846a79df]
#8    Source "../../third_party/webrtc/rtc_base/operations_chain.h", line 145, in void rtc::OperationsChain::ChainOperation<webrtc::PeerConnection::SetRemoteDescription(std::unique_ptr<webrtc::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >, rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface>)::{lambda(std::function<void ()>)#1}>(webrtc::PeerConnection::SetRemoteDescription(std::unique_ptr<webrtc::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >, rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface>)::{lambda(std::function<void ()>)#1}&&) [0x5560846d595f]
#7    Source "../../third_party/webrtc/rtc_base/operations_chain.h", line 65, in rtc::rtc_operations_chain_internal::OperationWithFunctor<webrtc::PeerConnection::SetRemoteDescription(std::unique_ptr<webrtc::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >, rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface>)::{lambda(std::function<void ()>)#1}>::Run() [0x5560846dab7c]
#6    Source "../../third_party/webrtc/pc/peer_connection.cc", line 2979, in webrtc::PeerConnection::SetRemoteDescription(std::unique_ptr<webrtc::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >, rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface>)::{lambda(std::function<void ()>)#1}::operator()(std::function<void ()>) [0x5560846a7849]
#5    Source "../../third_party/webrtc/pc/peer_connection.cc", line 3056, in webrtc::PeerConnection::DoSetRemoteDescription(std::unique_ptr<webrtc::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >, rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface>) [0x5560846a8645]
#4    Source "../../third_party/webrtc/pc/peer_connection.cc", line 3162, in webrtc::PeerConnection::ApplyRemoteDescription(std::unique_ptr<webrtc::SessionDescriptionInterface, std::default_delete<webrtc::SessionDescriptionInterface> >) [0x5560846a9272]
#3    Source "../../third_party/webrtc/pc/peer_connection.cc", line 6020, in webrtc::PeerConnection::UpdateSessionState(webrtc::SdpType, cricket::ContentSource, cricket::SessionDescription const*) [0x5560846c664e]
#2    Source "../../third_party/webrtc/pc/peer_connection.cc", line 4806, in webrtc::PeerConnection::ChangeSignalingState(webrtc::PeerConnectionInterface::SignalingState) [0x5560846bd98d]
#1    Source "../../talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc", line 581, in owt::p2p::P2PPeerConnectionChannel::OnSignalingChange(webrtc::PeerConnectionInterface::SignalingState) [0x556083b7b5c7]
#0    Source "../../talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc", line 1301, in owt::p2p::P2PPeerConnectionChannel::DrainPendingRemoteCandidates() [0x556083b82c95]
Segmentation fault (Address not mapped to object [(nil)])
[service:WEBRTC_SERVER] [node_id:takeda-pilot-node1] 2023-06-06 10:39:32,277 main.py MainProcess MainThread INFO     webrtc_server exited with error code 1. Restarting webrtc_server.
```