### PR TITLE
Ignore out/ directory for git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /base
 /build
 /buildtools
-/out*/
+/out
 /testing
 /third_party
 /tools


### PR DESCRIPTION
I think the git ignore was mis-specified, as I was seeing this:
![image](https://github.com/AmbientAI/owt-client-native/assets/32236720/27ddc8ce-48f5-4efe-b4a2-ee0d3b6453c6)

With this change, I see a clean `git status`