### PR TITLE
[AMB-18183] webrtc_server/owt: Callers of GetPeerConnectionRef() should ensure it's non-null where appropriate

### DIFF
--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -174,6 +174,12 @@ void P2PPeerConnectionChannel::Publish(
     RTC_LOG(LS_INFO) << "Peer connection closed, returning.";
     // Skip on_success callback because we haven't published anything.
     ClearPendingStreams();
+    if (on_failure) {
+      std::unique_ptr<Exception> e(
+          new Exception(ExceptionType::kP2PClientRemoteNotExisted,
+                        "Peer connection closed."));
+      on_failure(std::move(e));
+    }
     return;
   }
 
@@ -873,6 +879,12 @@ void P2PPeerConnectionChannel::Unpublish(
     RTC_LOG(LS_INFO) << "Peer connection closed, returning.";
     // Skip on_success callback because technically we did not unpublish anything.
     ClearPendingStreams();
+    if (on_failure) {
+      std::unique_ptr<Exception> e(
+          new Exception(ExceptionType::kP2PClientRemoteNotExisted,
+                        "Peer connection closed."));
+      on_failure(std::move(e));
+    }
     return;
   }
 

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -158,6 +158,11 @@ void P2PPeerConnectionChannel::Publish(
   RTC_LOG(LS_INFO) << "Publishing a local stream.";
   // Add reference to peer connection until end of function.
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
+  if (!temp_pc_) {
+    RTC_LOG(LS_INFO) << "Peer connection closed, returning.";
+    return;
+  }
+
   if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
     RTC_LOG(LS_INFO) << "Local stream cannot be nullptr.";
     return;
@@ -431,7 +436,11 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
   RTC_LOG(LS_INFO) << "Received message type: " << type;
   // Store reference so peer_connection_ is not deleted until function ends
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
-  if (!temp_pc_) { return; }
+  if (!temp_pc_) {
+    RTC_LOG(LS_INFO) << "Peer connection closed, returning.";
+    return;
+  }
+
   if (type == "offer" || type == "answer") {
     if (type == "offer" && session_state_ == kSessionStateMatched) {
       ChangeSessionState(kSessionStateConnecting);
@@ -548,6 +557,10 @@ void P2PPeerConnectionChannel::OnSignalingChange(
   RTC_LOG(LS_INFO) << "Signaling state changed: " << new_state;
 
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
+  if (!temp_pc_) {
+    RTC_LOG(LS_INFO) << "Peer connection closed, returning.";
+    return;
+  }
 
   switch (new_state) {
     case PeerConnectionInterface::SignalingState::kStable:
@@ -841,6 +854,11 @@ void P2PPeerConnectionChannel::Unpublish(
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
+  if (!temp_pc_) {
+    RTC_LOG(LS_INFO) << "Peer connection closed, returning.";
+    return;
+  }
+
   if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
     RTC_LOG(LS_WARNING) << "Local stream cannot be nullptr.";
     return;

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -171,6 +171,7 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   // Set remote capability flags based on UA.
   void HandleRemoteCapability(Json::Value& ua);
   void SendUaInfo();
+  void ClearPendingStreams();
   rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel_;
   P2PSignalingSenderInterface* signaling_sender_;
   std::string local_id_;


### PR DESCRIPTION
If the peer connection is closed, skip handling irrelevant changes.

This is a hypothetical fix but from reading up on it, it looks safe to skip these methods if the peer connection has been closed. 

What's not 100% clear is if `DrainPendingStreams()` can be skipped though. In `DrainPendingStreams` the real work only happens if the peer connection is still alive. So I think it's safe to skip, but perhaps we need to clear the instance variables `pending_publish_streams_` and `pending_unpublish_streams_`?