### PR TITLE
Implement support for request batching and hangups in the OWT layer

### DIFF
--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -178,6 +178,18 @@ class P2PClient final
                std::function<void(std::shared_ptr<P2PPublication>, std::string)> on_success,
                std::function<void(std::unique_ptr<Exception>)> on_failure);
   /**
+  @brief Triggered on batch hangups, when old streams are removed.
+  @param target_id Remote user's ID.
+  @param streams The streams which will be unpublished.
+  @param on_success Success callback will be invoked if the stream is successfully removed.
+  @param on_failure Failure callback will be invoked if an exception is encountered. Currently unused.
+  */
+  void UnpublishBatch(const std::string& target_id,
+                 std::vector<std::shared_ptr<LocalStream>> streams,
+                 std::function<void()> on_success,
+                 std::function<void(std::unique_ptr<Exception>)> on_failure);
+
+  /**
    @brief Send a message to remote client
    @param target_id Remote user's ID.
    @param message The message to be sent.

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -162,6 +162,22 @@ class P2PClient final
                std::function<void(std::shared_ptr<P2PPublication>)> on_success,
                std::function<void(std::unique_ptr<Exception>)> on_failure);
   /**
+   @brief Publish a batch of streams to the remote client.
+   @param streams The streams which will be published.
+   @param target_id Target user's ID.
+   @param on_success Success callback will be invoked (per stream) if the stream is
+   published, passing in P2PPublication and the newly created Stream's ID.
+   @param on_failure Failure callback will be invoked (per stream) if one of these cases
+   happened:
+                    1. P2PClient is disconnected from server.
+                    2. Target ID is null or user is offline.
+                    3. Haven't connected to remote client.
+   */
+  void PublishBatch(const std::string& target_id,
+               std::vector<std::shared_ptr<owt::base::LocalStream>> streams,
+               std::function<void(std::shared_ptr<P2PPublication>, std::string)> on_success,
+               std::function<void(std::unique_ptr<Exception>)> on_failure);
+  /**
    @brief Send a message to remote client
    @param target_id Remote user's ID.
    @param message The message to be sent.

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2ppublication.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2ppublication.h
@@ -36,7 +36,6 @@ class P2PPublication : public Publication {
   void StopUnpublishedStream();
   /// Pause current publication's audio or/and video basing on |track_kind| provided.
   /// Not supported in P2P yet.
-  std::shared_ptr<LocalStream> GetLocalStream() const { return local_stream_; }
   void Mute(TrackKind track_kind,
             std::function<void()> on_success,
             std::function<void(std::unique_ptr<Exception>)> on_failure) override {}
@@ -49,6 +48,9 @@ class P2PPublication : public Publication {
   void AddObserver(PublicationObserver& observer) override;
   /// Unregister an observer from this p2p publication.
   void RemoveObserver(PublicationObserver& observer) override;
+  // Return the local stream associated with this publication.
+  std::shared_ptr<LocalStream> GetLocalStream() const { return local_stream_; }
+
  private:
   std::string target_id_;
   std::shared_ptr<LocalStream> local_stream_;

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2ppublication.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2ppublication.h
@@ -32,8 +32,11 @@ class P2PPublication : public Publication {
       std::function<void(std::unique_ptr<Exception>)> on_failure) override;
   /// Stop current publication.
   void Stop() override;
+  // Stop the unpublished stream. Called when batch removing streams.
+  void StopUnpublishedStream();
   /// Pause current publication's audio or/and video basing on |track_kind| provided.
   /// Not supported in P2P yet.
+  std::shared_ptr<LocalStream> GetLocalStream() const { return local_stream_; }
   void Mute(TrackKind track_kind,
             std::function<void()> on_success,
             std::function<void(std::unique_ptr<Exception>)> on_failure) override {}

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -163,6 +163,93 @@ void P2PPeerConnectionChannel::ClearPendingStreams() {
   }
 }
 
+void P2PPeerConnectionChannel::PublishBatch(std::vector<std::shared_ptr<LocalStream>> streams,
+    std::function<void(std::shared_ptr<LocalStream>)> on_success,
+    std::function<void(std::unique_ptr<Exception>)> on_failure)
+{
+  // Add reference to peer connection until end of function.
+  rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
+
+  for (auto stream : streams) {
+    RTC_LOG(LS_INFO) << "Publishing a local stream.";
+    if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
+      RTC_LOG(LS_INFO) << "Local stream cannot be nullptr.";
+      return;
+    }
+    RTC_CHECK(stream->MediaStream());
+    std::string stream_label = stream->MediaStream()->id();
+    {
+      std::lock_guard<std::mutex> lock(published_streams_mutex_);
+      if (published_streams_.find(stream_label) != published_streams_.end() ||
+          publishing_streams_.find(stream_label) != publishing_streams_.end()) {
+        if (on_failure) {
+          std::unique_ptr<Exception> e(
+              new Exception(ExceptionType::kP2PClientInvalidArgument,
+                            "The stream is already published."));
+          on_failure(std::move(e));
+        }
+        return;
+      }
+    }
+    // Send chat-closed to workaround known browser bugs, together with
+    // user agent information once and once only.
+    {
+      std::lock_guard<std::mutex> lock(stop_send_mutex_);
+      if (stop_send_needed_) {
+        SendStop(nullptr, nullptr);
+        stop_send_needed_ = false;
+      }
+      if (!ua_sent_) {
+        SendUaInfo();
+        ua_sent_ = true;
+      }
+    }
+    rtc::scoped_refptr<webrtc::MediaStreamInterface> media_stream =
+        stream->MediaStream();
+    // Calling [stream|track]->id() runs on signaling_thread, so call outside of locks
+    std::string stream_id = media_stream->id();
+    std::pair<std::string, std::string> stream_track_info;
+    for (const auto& track : media_stream->GetAudioTracks()) {
+      std::string track_id = track->id();
+      {
+        std::lock_guard<std::mutex> lock(local_stream_tracks_info_mutex_);
+        if (local_stream_tracks_info_.find(track_id) ==
+            local_stream_tracks_info_.end()) {
+          stream_track_info = std::make_pair(track_id, stream_id);
+          local_stream_tracks_info_.insert(stream_track_info);
+        }
+      }
+    }
+    for (const auto& track : media_stream->GetVideoTracks()) {
+      std::string track_id = track->id();
+      {
+        std::lock_guard<std::mutex> lock(local_stream_tracks_info_mutex_);
+        if (local_stream_tracks_info_.find(track_id) ==
+            local_stream_tracks_info_.end()) {
+          stream_track_info = std::make_pair(track_id, stream_id);
+          local_stream_tracks_info_.insert(stream_track_info);
+        }
+      }
+    }
+    {
+      std::lock_guard<std::mutex> lock(pending_publish_streams_mutex_);
+      pending_publish_streams_.push_back(stream);
+    }
+    {
+      std::lock_guard<std::mutex> lock(published_streams_mutex_);
+      publishing_streams_.insert(stream_label);
+    }
+    RTC_LOG(LS_INFO) << "Session state: " << session_state_;
+    if (on_success) {
+      on_success(stream);
+    }
+  }
+
+  // With the batched call, we make a single call to DrainPendingStreams() for
+  // the entire batch. This saves a lot of chatter on the signaling channel.
+  DrainPendingStreams();
+}
+
 void P2PPeerConnectionChannel::Publish(
     std::shared_ptr<LocalStream> stream,
     std::function<void()> on_success,
@@ -256,6 +343,7 @@ void P2PPeerConnectionChannel::Publish(
   }
   DrainPendingStreams();
 }
+
 void P2PPeerConnectionChannel::Send(
     const std::string& message,
     std::function<void()> on_success,

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -186,8 +186,8 @@ void P2PPeerConnectionChannel::PublishBatch(std::vector<std::shared_ptr<LocalStr
   for (auto stream : streams) {
     RTC_LOG(LS_INFO) << "Publishing a local stream.";
     if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
-      RTC_LOG(LS_INFO) << "Local stream cannot be nullptr.";
-      return;
+      RTC_LOG(LS_INFO) << "Local stream cannot be nullptr. Skipping.";
+      continue;
     }
     RTC_CHECK(stream->MediaStream());
     std::string stream_label = stream->MediaStream()->id();
@@ -201,7 +201,7 @@ void P2PPeerConnectionChannel::PublishBatch(std::vector<std::shared_ptr<LocalStr
                             "The stream is already published."));
           on_failure(std::move(e));
         }
-        return;
+        continue;
       }
     }
     // Send chat-closed to workaround known browser bugs, together with

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -170,6 +170,19 @@ void P2PPeerConnectionChannel::PublishBatch(std::vector<std::shared_ptr<LocalStr
   // Add reference to peer connection until end of function.
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
 
+  if (!temp_pc_) {
+    RTC_LOG(LS_INFO) << "Peer connection closed, returning.";
+    // Skip on_success callback because we haven't published anything.
+    ClearPendingStreams();
+    if (on_failure) {
+      std::unique_ptr<Exception> e(
+          new Exception(ExceptionType::kP2PClientRemoteNotExisted,
+                        "Peer connection closed."));
+      on_failure(std::move(e));
+    }
+    return;
+  }
+
   for (auto stream : streams) {
     RTC_LOG(LS_INFO) << "Publishing a local stream.";
     if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
@@ -1024,6 +1037,19 @@ void P2PPeerConnectionChannel::UnpublishBatch(std::vector<std::shared_ptr<LocalS
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
+  if (!temp_pc_) {
+    RTC_LOG(LS_INFO) << "Peer connection closed, returning.";
+    // Skip on_success callback because technically we did not unpublish anything.
+    ClearPendingStreams();
+    if (on_failure) {
+      std::unique_ptr<Exception> e(
+          new Exception(ExceptionType::kP2PClientRemoteNotExisted,
+                        "Peer connection closed."));
+      on_failure(std::move(e));
+    }
+    return;
+  }
+
   for (auto stream : streams) {
     if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
       RTC_LOG(LS_WARNING) << "Local stream cannot be nullptr. Continuing";

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1019,6 +1019,41 @@ void P2PPeerConnectionChannel::Unpublish(
   }
   DrainPendingStreams();
 }
+
+void P2PPeerConnectionChannel::UnpublishBatch(std::vector<std::shared_ptr<LocalStream>> streams,
+    std::function<void()> on_success,
+    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
+  for (auto stream : streams) {
+    if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
+      RTC_LOG(LS_WARNING) << "Local stream cannot be nullptr. Continuing";
+      continue;
+    }
+
+    RTC_CHECK(stream->MediaStream());
+    // Calling MediaStream->id() runs on signaling_thread, so must be outside locks.
+    std::string stream_id = stream->MediaStream()->id();
+    {
+      std::lock_guard<std::mutex> lock(published_streams_mutex_);
+      auto it = published_streams_.find(stream_id);
+      if (it == published_streams_.end()) {
+        RTC_LOG(LS_ERROR) << "Did not find published stream.";
+      } else {
+        RTC_LOG(LS_ERROR) << "Found published stream.";
+        published_streams_.erase(it);
+      }
+    }
+    {
+      std::lock_guard<std::mutex> lock(pending_unpublish_streams_mutex_);
+      pending_unpublish_streams_.push_back(stream);
+    }
+    if (on_success) {
+      on_success();
+    }
+  }
+  DrainPendingStreams();
+}
+
 void P2PPeerConnectionChannel::Stop(
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -79,6 +79,10 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   void Unpublish(std::shared_ptr<LocalStream> stream,
                  std::function<void()> on_success,
                  std::function<void(std::unique_ptr<Exception>)> on_failure);
+  // Unpublish a batch of local streams to remote user.
+  void UnpublishBatch(std::vector<std::shared_ptr<LocalStream>> streams,
+                      std::function<void()> on_success,
+                      std::function<void(std::unique_ptr<Exception>)> on_failure);
   // Send message to remote user.
   void Send(const std::string& message,
             std::function<void()> on_success,

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -71,6 +71,10 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   void Publish(std::shared_ptr<LocalStream> stream,
                std::function<void()> on_success,
                std::function<void(std::unique_ptr<Exception>)> on_failure);
+  // Publish a batch of local streams to remote user.
+  void PublishBatch(std::vector<std::shared_ptr<LocalStream>> streams,
+                    std::function<void(std::shared_ptr<LocalStream>)> on_success,
+                    std::function<void(std::unique_ptr<Exception>)> on_failure);
   // Unpublish a local stream to remote user.
   void Unpublish(std::shared_ptr<LocalStream> stream,
                  std::function<void()> on_success,

--- a/talk/owt/sdk/p2p/p2ppublication.cc
+++ b/talk/owt/sdk/p2p/p2ppublication.cc
@@ -72,6 +72,23 @@ void P2PPublication::Stop() {
       (*its).get().OnEnded();
   }
 }
+
+// Stop current publication for an unpublished stream.
+void P2PPublication::StopUnpublishedStream() {
+  auto that = p2p_client_.lock();
+  if (that == nullptr || ended_) {
+    return;
+  } else {
+    // Caller is responsible for unpublishing the stream before calling this method.
+    // Caller should do the equivalent of the following:
+    // that->Unpublish(target_id_, local_stream_, nullptr, nullptr);
+    ended_ = true;
+    const std::lock_guard<std::mutex> lock(observer_mutex_);
+    for (auto its = observers_.begin(); its != observers_.end(); ++its)
+      (*its).get().OnEnded();
+  }
+}
+
 void P2PPublication::AddObserver(PublicationObserver& observer) {
   const std::lock_guard<std::mutex> lock(observer_mutex_);
   std::vector<std::reference_wrapper<PublicationObserver>>::iterator it =


### PR DESCRIPTION
This PR adds support for batched new stream requests and hangups. The goal of supporting batching in the OWT layer is to avoid calling DrainPendingStreams() every time for N streams. Instead, we'll make one single call per batch of requests/hangups.

