### PR TITLE
[AMB-24748] Minimize ICE candidate exchange by configuring bundle_policy in OWT

### DIFF
--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -382,13 +382,19 @@ PeerConnectionChannelConfiguration P2PClient::GetPeerConnectionChannelConfigurat
   for (auto codec : configuration_.video_encodings) {
     config.video.push_back(VideoEncodingParameters(codec));
   }
-  for (auto codec : configuration_.audio_encodings) {
-    config.audio.push_back(AudioEncodingParameters(codec));
-  }
+  // sam: This is unused for Ambient. We don't support audio.
+  // for (auto codec : configuration_.audio_encodings) {
+  //   config.audio.push_back(AudioEncodingParameters(codec));
+  // }
   // TODO(jianlin): For publisher, peerconnection is created before UA info is received.
   // so signaling protocol change is needed if we would like to remove this HC.
   config.continual_gathering_policy =
       PeerConnectionInterface::ContinualGatheringPolicy::GATHER_CONTINUALLY;
+
+  // See webrtc/api/peer_connection_interface.h for details on the options
+  // https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-24#section-4.1.1
+  config.bundle_policy = webrtc::PeerConnectionInterface::BundlePolicy::kBundlePolicyMaxBundle;
+
   return config;
 }
 void P2PClient::OnMessageReceived(const std::string& remote_id,


### PR DESCRIPTION
Sets `bundle_policy` and `prioritize_most_like_ice_candidates_pairs` options in the `PeerConnectionChannelConfiguration`.

**Testing**
Video wall loads are noticeably faster now (~5s or so faster).
![image](https://github.com/AmbientAI/owt-client-native/assets/97262377/00b8e091-62f2-4965-a388-17ca46ca7cf5)

With the default config, we see 215 ice candidates exchanged when we first load a video wall of 16 streams:
![image](https://github.com/AmbientAI/owt-client-native/assets/97262377/3c29049f-7ff3-4bb9-87fb-d9864d3a072f)
![image](https://github.com/AmbientAI/owt-client-native/assets/97262377/4afe5005-4257-4c67-a44e-ee7228895d2a)

With the `bundle_policy` set to `kBundlePolicyMaxBundle`, we see 24 candidates exchanged for the same video wall (a **~9x reduction!**):
![image](https://github.com/AmbientAI/owt-client-native/assets/97262377/6a061f3e-3374-4aaf-a8be-74c870a1e2bc)

![image](https://github.com/AmbientAI/owt-client-native/assets/97262377/a68de0f1-0801-4476-8762-fc08e5cc8f86)
![image](https://github.com/AmbientAI/owt-client-native/assets/97262377/d99a2fba-faa5-4c75-8275-f71c1358510d)
