### PR TITLE
[AMB-39012, 1/n] Add configuration support for a custom encoder

### DIFF
--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -115,6 +115,8 @@ static_library("owt_sdk_base") {
       "sdk/base/customizedvideoencoderproxy.h",
       "sdk/base/customizedvideosource.cc",
       "sdk/base/customizedvideosource.h",
+      "sdk/base/dualvideoencoder.cc",
+      "sdk/base/dualvideoencoder.h",
       "sdk/base/encodedvideoencoderfactory.cc",
       "sdk/base/encodedvideoencoderfactory.h",
       "sdk/base/webrtcvideorendererimpl.cc",

--- a/talk/owt/sdk/base/dualvideoencoder.cc
+++ b/talk/owt/sdk/base/dualvideoencoder.cc
@@ -1,0 +1,33 @@
+#include "webrtc/api/video_codecs/builtin_video_encoder_factory.h"
+#include "talk/owt/sdk/base/dualvideoencoder.h"
+
+namespace owt {
+namespace base {
+
+
+DualVideoEncoder::DualVideoEncoder()
+    : builtin_encoder_factory_(webrtc::CreateBuiltinVideoEncoderFactory())
+{}
+
+
+std::unique_ptr<webrtc::VideoEncoder> DualVideoEncoder::CreateVideoEncoder(
+    const webrtc::SdpVideoFormat& format
+) {
+    return builtin_encoder_factory_->CreateVideoEncoder(format);
+}
+
+
+std::vector<webrtc::SdpVideoFormat> DualVideoEncoder::GetSupportedFormats() const
+{
+    return builtin_encoder_factory_->GetSupportedFormats();
+}
+
+
+webrtc::VideoEncoderFactory::CodecInfo DualVideoEncoder::QueryVideoEncoder(const webrtc::SdpVideoFormat& format) const
+{
+    return builtin_encoder_factory_->QueryVideoEncoder(format);
+}
+
+
+} // namespace base
+} // namespace owt

--- a/talk/owt/sdk/base/dualvideoencoder.h
+++ b/talk/owt/sdk/base/dualvideoencoder.h
@@ -1,0 +1,30 @@
+#ifndef OWT_BASE_DUALVIDEOENCODER_H_
+#define OWT_BASE_DUALVIDEOENCODER_H_
+
+#include <vector>
+
+#include "webrtc/api/video_codecs/sdp_video_format.h"
+#include "webrtc/api/video_codecs/video_encoder.h"
+#include "webrtc/api/video_codecs/video_encoder_factory.h"
+
+namespace owt {
+namespace base {
+
+
+class DualVideoEncoder : public webrtc::VideoEncoderFactory {
+ public:
+  DualVideoEncoder();
+  virtual ~DualVideoEncoder(){}
+  /* Implement webrtc::VideoEncoderFactory */
+  std::unique_ptr<webrtc::VideoEncoder> CreateVideoEncoder(const webrtc::SdpVideoFormat& format) override;
+  std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
+  webrtc::VideoEncoderFactory::CodecInfo QueryVideoEncoder(const webrtc::SdpVideoFormat& format) const override;
+ private:
+  std::unique_ptr<webrtc::VideoEncoderFactory> builtin_encoder_factory_;
+};
+
+
+}  // namespace base
+}  // namespace owt
+
+#endif  // OWT_BASE_DUALVIDEOENCODER_H_

--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -9,6 +9,7 @@ namespace base {
 bool GlobalConfiguration::hardware_acceleration_enabled_ = true;
 #endif
 bool GlobalConfiguration::encoded_frame_ = false;
+bool GlobalConfiguration::dual_video_encoder_ = false;
 std::unique_ptr<AudioFrameGeneratorInterface>
     GlobalConfiguration::audio_frame_generator_ = nullptr;
 std::unique_ptr<VideoDecoderInterface>

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -155,7 +155,7 @@ void PeerConnectionDependencyFactory::
 #elif defined(WEBRTC_LINUX)
   // MSDK support for Linux is not in place. Use default.
   if (dual_video_encoder_) {
-    RTC_LOG(LS_WARNING) << "Using DualVideoEncoder";
+    RTC_LOG(LS_WARNING) << "Using DualVideoEncoder. The EncodedVideoFrameEnabled configuration is ignored.";
     encoder_factory.reset(new DualVideoEncoder());
   } else if (encoded_frame_) {
     encoder_factory.reset(new EncodedVideoEncoderFactory());

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -31,6 +31,9 @@
 #if defined(WEBRTC_LINUX) || defined(WEBRTC_WIN)
 #include "talk/owt/sdk/base/customizedvideodecoderfactory.h"
 #endif
+#if defined(WEBRTC_LINUX)
+#include "talk/owt/sdk/base/dualvideoencoder.h"
+#endif
 #include "owt/base/clientconfiguration.h"
 #include "owt/base/globalconfiguration.h"
 using namespace rtc;
@@ -61,6 +64,7 @@ PeerConnectionDependencyFactory::PeerConnectionDependencyFactory()
   network_monitor_ = nullptr;
 #endif
   encoded_frame_ = GlobalConfiguration::GetEncodedVideoFrameEnabled();
+  dual_video_encoder_ = GlobalConfiguration::GetDualVideoEncoderEnabled();
   pc_thread_->SetName("peerconnection_dependency_factory_thread", nullptr);
   pc_thread_->Start();
 }
@@ -150,7 +154,10 @@ void PeerConnectionDependencyFactory::
 
 #elif defined(WEBRTC_LINUX)
   // MSDK support for Linux is not in place. Use default.
-  if (encoded_frame_) {
+  if (dual_video_encoder_) {
+    RTC_LOG(LS_WARNING) << "Using DualVideoEncoder";
+    encoder_factory.reset(new DualVideoEncoder());
+  } else if (encoded_frame_) {
     encoder_factory.reset(new EncodedVideoEncoderFactory());
   } else {
     encoder_factory = webrtc::CreateBuiltinVideoEncoderFactory();

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.h
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.h
@@ -91,6 +91,7 @@ class PeerConnectionDependencyFactory : public rtc::RefCountInterface {
                                                // VP8, H.264 & HEVC enc/dec
 #endif
   bool encoded_frame_;
+  bool dual_video_encoder_;
 #if defined(WEBRTC_IOS)
   rtc::NetworkMonitorInterface* network_monitor_;
 #endif

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -66,6 +66,14 @@ class GlobalConfiguration {
   }
   /** @endcond */
   /**
+   @brief This function sets the video encoder to be a custom video encoder that
+   supports both raw and encoded video frames.
+   @param enabled Dual video encoder is enabled or not.
+   */
+  static void SetDualVideoEncoderEnabled(bool enabled) {
+    dual_video_encoder_ = enabled;
+  }
+  /**
    @brief This function sets the audio input to be an instance of
    AudioFrameGeneratorInterface.
    @details When it is enabled, SDK will not capture audio from mic. This means
@@ -172,6 +180,13 @@ class GlobalConfiguration {
      return encoded_frame_;
   }
   /**
+   @brief This function gets whether the dual video encoder is enabled or not.
+   @return true or false.
+   */
+  static bool GetDualVideoEncoderEnabled() {
+    return dual_video_encoder_;
+  }
+  /**
    @brief This function gets whether the customized audio input is enabled or not.
    @return true or false.
    */
@@ -220,6 +235,11 @@ class GlobalConfiguration {
    * be published.
    */
   static bool encoded_frame_;
+  /**
+   * Default is false. If it is set to true, uses a dual video encoder that
+   * supports both raw and encoded video frames.
+   */
+  static bool dual_video_encoder_;
   static std::unique_ptr<AudioFrameGeneratorInterface> audio_frame_generator_;
   /**
    @brief This function returns flag indicating whether customized video decoder is enabled or not


### PR DESCRIPTION
# Summary
This is some initial boilerplate to adding a "pass-through encoder" to the OWT framework. More specifically, we want an "Video Encoder Factory" to invisibly handle raw frames (which need encoding) and encoded packets (which just need a passthrough).

This is a quirk of WebRTC where you need a singleton `VideoEncoderFactory`. We need to be able to handle both the case of encoded frames (for live streams from transcoder) and raw packets (SPE streams from engine, archival streams from nvr_streamer).

## Context
This is the general framework for a passthrough encoder:
![image](https://github.com/user-attachments/assets/219a5232-4ac2-4216-88d6-0bff25320769)

# Testing
- This code compiles
- This code runs with existing appliance
- This code runs when I enable the DualVideoEncoder in the existing appliance