### PR TITLE
Add DualVideoEncoder implementation with HybridVideoEncoder class

### DIFF
--- a/talk/owt/sdk/base/customizedvideoencoderproxy.h
+++ b/talk/owt/sdk/base/customizedvideoencoderproxy.h
@@ -42,7 +42,6 @@ class CustomizedVideoEncoderProxy : public webrtc::VideoEncoder {
   VideoEncoderInterface* external_encoder_;
   uint8_t gof_idx_;
   webrtc::GofInfoVP9 gof_;
-  bool encode_called_ = false;
 };
 }
 }

--- a/talk/owt/sdk/base/dualvideoencoder.cc
+++ b/talk/owt/sdk/base/dualvideoencoder.cc
@@ -125,6 +125,12 @@ class HybridVideoEncoder : public webrtc::VideoEncoder {
       info = raw_encoder_->GetEncoderInfo();
     } else if (encoded_encoder_ != nullptr) {
       info = encoded_encoder_->GetEncoderInfo();
+      // The hybrid encoder may receive EncodedFrameBuffer instances whose
+      // ToI420() intentionally aborts. Advertise that contract explicitly so
+      // WebRTC does not try to adapt/scale native encoded frames before Encode()
+      // gets a chance to dispatch them to the passthrough encoder.
+      info.scaling_settings = VideoEncoder::ScalingSettings::kOff;
+      info.has_trusted_rate_controller = false;
     }
     info.supports_native_handle = true;
     info.implementation_name = "OWTDualVideoEncoder";

--- a/talk/owt/sdk/base/dualvideoencoder.cc
+++ b/talk/owt/sdk/base/dualvideoencoder.cc
@@ -195,17 +195,17 @@ class HybridVideoEncoder : public webrtc::VideoEncoder {
 
 
 DualVideoEncoder::DualVideoEncoder()
-    : builtin_encoder_factory_(webrtc::CreateBuiltinVideoEncoderFactory())
+    : builtin_encoder_factory_(webrtc::CreateBuiltinVideoEncoderFactory()),
+      encoded_encoder_factory_(std::make_unique<EncodedVideoEncoderFactory>())
 {}
 
 
 std::unique_ptr<webrtc::VideoEncoder> DualVideoEncoder::CreateVideoEncoder(
     const webrtc::SdpVideoFormat& format
 ) {
-    EncodedVideoEncoderFactory encoded_encoder_factory;
     return std::make_unique<HybridVideoEncoder>(
         builtin_encoder_factory_->CreateVideoEncoder(format),
-        encoded_encoder_factory.CreateVideoEncoder(format));
+        encoded_encoder_factory_->CreateVideoEncoder(format));
 }
 
 
@@ -213,8 +213,7 @@ std::vector<webrtc::SdpVideoFormat> DualVideoEncoder::GetSupportedFormats() cons
 {
     std::vector<webrtc::SdpVideoFormat> supported_formats =
         builtin_encoder_factory_->GetSupportedFormats();
-    EncodedVideoEncoderFactory encoded_encoder_factory;
-    for (const auto& format : encoded_encoder_factory.GetSupportedFormats()) {
+    for (const auto& format : encoded_encoder_factory_->GetSupportedFormats()) {
         bool already_present = false;
         for (const auto& existing_format : supported_formats) {
             if (existing_format.name == format.name &&

--- a/talk/owt/sdk/base/dualvideoencoder.cc
+++ b/talk/owt/sdk/base/dualvideoencoder.cc
@@ -36,8 +36,14 @@ class HybridVideoEncoder : public webrtc::VideoEncoder {
     has_codec_settings_ = true;
     number_of_cores_ = number_of_cores;
     max_payload_size_ = max_payload_size;
-    encoded_encoder_initialized_ = false;
-    raw_encoder_initialized_ = false;
+    if (raw_encoder_initialized_ && raw_encoder_) {
+      raw_encoder_->Release();
+      raw_encoder_initialized_ = false;
+    }
+    if (encoded_encoder_initialized_ && encoded_encoder_) {
+      encoded_encoder_->Release();
+      encoded_encoder_initialized_ = false;
+    }
     return WEBRTC_VIDEO_CODEC_OK;
   }
 

--- a/talk/owt/sdk/base/dualvideoencoder.cc
+++ b/talk/owt/sdk/base/dualvideoencoder.cc
@@ -54,10 +54,6 @@ class HybridVideoEncoder : public webrtc::VideoEncoder {
       return encoded_encoder_->Encode(input_image, frame_types);
     }
 
-    if (raw_encoder_ == nullptr) {
-      RTC_LOG(LS_ERROR) << "Raw video frame received without a raw encoder.";
-      return WEBRTC_VIDEO_CODEC_ERROR;
-    }
     if (!EnsureEncoderInitialized(raw_encoder_.get(), raw_encoder_initialized_)) {
       RTC_LOG(LS_ERROR) << "Failed to initialize raw video encoder.";
       return WEBRTC_VIDEO_CODEC_ERROR;

--- a/talk/owt/sdk/base/dualvideoencoder.cc
+++ b/talk/owt/sdk/base/dualvideoencoder.cc
@@ -127,13 +127,9 @@ class HybridVideoEncoder : public webrtc::VideoEncoder {
       info = raw_encoder_->GetEncoderInfo();
     } else if (encoded_encoder_ != nullptr) {
       info = encoded_encoder_->GetEncoderInfo();
-      // The hybrid encoder may receive EncodedFrameBuffer instances whose
-      // ToI420() intentionally aborts. Advertise that contract explicitly so
-      // WebRTC does not try to adapt/scale native encoded frames before Encode()
-      // gets a chance to dispatch them to the passthrough encoder.
-      info.scaling_settings = VideoEncoder::ScalingSettings::kOff;
-      info.has_trusted_rate_controller = false;
     }
+    info.scaling_settings = VideoEncoder::ScalingSettings::kOff;
+    info.has_trusted_rate_controller = false;
     info.supports_native_handle = true;
     info.implementation_name = "OWTDualVideoEncoder";
     return info;

--- a/talk/owt/sdk/base/dualvideoencoder.cc
+++ b/talk/owt/sdk/base/dualvideoencoder.cc
@@ -1,0 +1,243 @@
+#include <utility>
+
+#include "webrtc/api/video_codecs/builtin_video_encoder_factory.h"
+#include "talk/owt/sdk/base/customizedencoderbufferhandle.h"
+#include "talk/owt/sdk/base/customizedvideoencoderproxy.h"
+#include "talk/owt/sdk/base/dualvideoencoder.h"
+#include "talk/owt/sdk/base/encodedvideoencoderfactory.h"
+#include "webrtc/modules/video_coding/include/video_error_codes.h"
+#include "webrtc/rtc_base/logging.h"
+
+namespace owt {
+namespace base {
+
+namespace {
+
+class HybridVideoEncoder : public webrtc::VideoEncoder {
+ public:
+  HybridVideoEncoder(std::unique_ptr<webrtc::VideoEncoder> raw_encoder,
+                     std::unique_ptr<webrtc::VideoEncoder> encoded_encoder)
+      : raw_encoder_(std::move(raw_encoder)),
+        encoded_encoder_(std::move(encoded_encoder)),
+        callback_(nullptr),
+        encoded_encoder_initialized_(false),
+        raw_encoder_initialized_(false),
+        has_codec_settings_(false),
+        number_of_cores_(0),
+        max_payload_size_(0) {}
+
+  int InitEncode(const webrtc::VideoCodec* codec_settings,
+                 int number_of_cores,
+                 size_t max_payload_size) override {
+    if (codec_settings == nullptr) {
+      return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+    }
+    codec_settings_ = *codec_settings;
+    has_codec_settings_ = true;
+    number_of_cores_ = number_of_cores;
+    max_payload_size_ = max_payload_size;
+    encoded_encoder_initialized_ = false;
+    raw_encoder_initialized_ = false;
+    return WEBRTC_VIDEO_CODEC_OK;
+  }
+
+  int32_t Encode(
+      const webrtc::VideoFrame& input_image,
+      const std::vector<webrtc::VideoFrameType>* frame_types) override {
+    if (input_image.video_frame_buffer()->type() ==
+        webrtc::VideoFrameBuffer::Type::kNative) {
+      if (!EnsureEncoderInitialized(encoded_encoder_.get(),
+                                    encoded_encoder_initialized_)) {
+        RTC_LOG(LS_ERROR) << "Failed to initialize passthrough video encoder.";
+        return WEBRTC_VIDEO_CODEC_ERROR;
+      }
+      return encoded_encoder_->Encode(input_image, frame_types);
+    }
+
+    if (raw_encoder_ == nullptr) {
+      RTC_LOG(LS_ERROR) << "Raw video frame received without a raw encoder.";
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+    if (!EnsureEncoderInitialized(raw_encoder_.get(), raw_encoder_initialized_)) {
+      RTC_LOG(LS_ERROR) << "Failed to initialize raw video encoder.";
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+    return raw_encoder_->Encode(input_image, frame_types);
+  }
+
+  int RegisterEncodeCompleteCallback(
+      webrtc::EncodedImageCallback* callback) override {
+    callback_ = callback;
+    int status = WEBRTC_VIDEO_CODEC_OK;
+    if (raw_encoder_ != nullptr) {
+      status = raw_encoder_->RegisterEncodeCompleteCallback(callback);
+      if (status != WEBRTC_VIDEO_CODEC_OK) {
+        return status;
+      }
+    }
+    if (encoded_encoder_ != nullptr) {
+      status = encoded_encoder_->RegisterEncodeCompleteCallback(callback);
+    }
+    return status;
+  }
+
+  void SetRates(const RateControlParameters& parameters) override {
+    latest_rate_parameters_.reset(new RateControlParameters(parameters));
+    if (raw_encoder_initialized_) {
+      raw_encoder_->SetRates(parameters);
+    }
+    if (encoded_encoder_initialized_) {
+      encoded_encoder_->SetRates(parameters);
+    }
+  }
+
+  void OnPacketLossRateUpdate(float packet_loss_rate) override {
+    if (raw_encoder_initialized_) {
+      raw_encoder_->OnPacketLossRateUpdate(packet_loss_rate);
+    }
+    if (encoded_encoder_initialized_) {
+      encoded_encoder_->OnPacketLossRateUpdate(packet_loss_rate);
+    }
+  }
+
+  void OnRttUpdate(int64_t rtt_ms) override {
+    if (raw_encoder_initialized_) {
+      raw_encoder_->OnRttUpdate(rtt_ms);
+    }
+    if (encoded_encoder_initialized_) {
+      encoded_encoder_->OnRttUpdate(rtt_ms);
+    }
+  }
+
+  void OnLossNotification(
+      const LossNotification& loss_notification) override {
+    if (raw_encoder_initialized_) {
+      raw_encoder_->OnLossNotification(loss_notification);
+    }
+    if (encoded_encoder_initialized_) {
+      encoded_encoder_->OnLossNotification(loss_notification);
+    }
+  }
+
+  EncoderInfo GetEncoderInfo() const override {
+    EncoderInfo info;
+    if (raw_encoder_ != nullptr) {
+      info = raw_encoder_->GetEncoderInfo();
+    } else if (encoded_encoder_ != nullptr) {
+      info = encoded_encoder_->GetEncoderInfo();
+    }
+    info.supports_native_handle = true;
+    info.implementation_name = "OWTDualVideoEncoder";
+    return info;
+  }
+
+  int Release() override {
+    int status = WEBRTC_VIDEO_CODEC_OK;
+    if (raw_encoder_ != nullptr) {
+      status = raw_encoder_->Release();
+      raw_encoder_initialized_ = false;
+    }
+    if (encoded_encoder_ != nullptr) {
+      const int encoded_status = encoded_encoder_->Release();
+      encoded_encoder_initialized_ = false;
+      if (status == WEBRTC_VIDEO_CODEC_OK) {
+        status = encoded_status;
+      }
+    }
+    latest_rate_parameters_.reset();
+    return status;
+  }
+
+ private:
+  bool EnsureEncoderInitialized(webrtc::VideoEncoder* encoder,
+                                bool& initialized) {
+    if (initialized) {
+      return true;
+    }
+    if (encoder == nullptr || !has_codec_settings_) {
+      return false;
+    }
+    if (callback_ != nullptr) {
+      const int callback_status =
+          encoder->RegisterEncodeCompleteCallback(callback_);
+      if (callback_status != WEBRTC_VIDEO_CODEC_OK) {
+        RTC_LOG(LS_ERROR) << "Failed to register encoder callback.";
+        return false;
+      }
+    }
+    const int init_status =
+        encoder->InitEncode(&codec_settings_, number_of_cores_,
+                            max_payload_size_);
+    if (init_status != WEBRTC_VIDEO_CODEC_OK) {
+      RTC_LOG(LS_ERROR) << "InitEncode failed for hybrid sub-encoder.";
+      return false;
+    }
+    initialized = true;
+    if (latest_rate_parameters_) {
+      encoder->SetRates(*latest_rate_parameters_);
+    }
+    return true;
+  }
+
+  std::unique_ptr<webrtc::VideoEncoder> raw_encoder_;
+  std::unique_ptr<webrtc::VideoEncoder> encoded_encoder_;
+  webrtc::EncodedImageCallback* callback_;
+  bool encoded_encoder_initialized_;
+  bool raw_encoder_initialized_;
+  webrtc::VideoCodec codec_settings_;
+  bool has_codec_settings_;
+  int number_of_cores_;
+  size_t max_payload_size_;
+  std::unique_ptr<RateControlParameters> latest_rate_parameters_;
+};
+
+}  // namespace
+
+
+DualVideoEncoder::DualVideoEncoder()
+    : builtin_encoder_factory_(webrtc::CreateBuiltinVideoEncoderFactory())
+{}
+
+
+std::unique_ptr<webrtc::VideoEncoder> DualVideoEncoder::CreateVideoEncoder(
+    const webrtc::SdpVideoFormat& format
+) {
+    EncodedVideoEncoderFactory encoded_encoder_factory;
+    return std::make_unique<HybridVideoEncoder>(
+        builtin_encoder_factory_->CreateVideoEncoder(format),
+        encoded_encoder_factory.CreateVideoEncoder(format));
+}
+
+
+std::vector<webrtc::SdpVideoFormat> DualVideoEncoder::GetSupportedFormats() const
+{
+    std::vector<webrtc::SdpVideoFormat> supported_formats =
+        builtin_encoder_factory_->GetSupportedFormats();
+    EncodedVideoEncoderFactory encoded_encoder_factory;
+    for (const auto& format : encoded_encoder_factory.GetSupportedFormats()) {
+        bool already_present = false;
+        for (const auto& existing_format : supported_formats) {
+            if (existing_format.name == format.name &&
+                existing_format.parameters == format.parameters) {
+                already_present = true;
+                break;
+            }
+        }
+        if (!already_present) {
+            supported_formats.push_back(format);
+        }
+    }
+    return supported_formats;
+}
+
+
+webrtc::VideoEncoderFactory::CodecInfo DualVideoEncoder::QueryVideoEncoder(const webrtc::SdpVideoFormat& format) const
+{
+    auto info = builtin_encoder_factory_->QueryVideoEncoder(format);
+    info.has_internal_source = false;
+    return info;
+}
+
+
+} // namespace base
+} // namespace owt

--- a/talk/owt/sdk/base/dualvideoencoder.h
+++ b/talk/owt/sdk/base/dualvideoencoder.h
@@ -21,6 +21,7 @@ class DualVideoEncoder : public webrtc::VideoEncoderFactory {
   webrtc::VideoEncoderFactory::CodecInfo QueryVideoEncoder(const webrtc::SdpVideoFormat& format) const override;
  private:
   std::unique_ptr<webrtc::VideoEncoderFactory> builtin_encoder_factory_;
+  std::unique_ptr<webrtc::VideoEncoderFactory> encoded_encoder_factory_;
 };
 
 


### PR DESCRIPTION
# Summary

This change completes the implementation of DualVideoEncoder so it can support both encoded passthrough frames and normal raw video frames within the same process.

Before this change, DualVideoEncoder boilerplate was added here - https://github.com/AmbientAI/owt-client-native/pull/42 before being abandoned.

With this PR, DualVideoEncoder becomes an actual hybrid encoder. It inspects the actual incoming frame type at encode time and routes:

* encoded/native-handle frames to the passthrough encoder path
* raw frames to the builtin WebRTC encoder path

# Details

This PR fills in DualVideoEncoder with a real hybrid implementation by introducing a private HybridVideoEncoder class inside the .cc file. HybridVideoEncoder holds both a builtin encoder and a passthrough encoder as sub-encoders, and dispatches to the right one at encode time.

* Frame dispatch (Encode): The routing key is VideoFrameBuffer::Type::kNative. The passthrough path (CustomizedVideoEncoderProxy) expects native-handle frames because the handle carries a CustomizedEncoderBufferHandle* with a VideoEncoderInterface* pointing to the actual encoder implementation. Raw frames have no such handle, so they go to the builtin path. There's no ambiguity — the frame's buffer type is set by the producer.
* Lazy initialization: Neither sub-encoder is initialized in InitEncode. Instead, EnsureEncoderInitialized is called on the first Encode call for each path. This matters because InitEncode is always called during PeerConnection negotiation, before any frames arrive. Eagerly initializing both encoders would force the passthrough encoder to initialize even when the stream only carries raw frames, which wastes resources and could trigger errors in codec setup for a path that's never used. By deferring, each sub-encoder self-initializes on its first frame. The codec settings, callback, and rate parameters are saved in HybridVideoEncoder and replayed into the sub-encoder at init time.
* Rate control forwarding (SetRates, OnPacketLossRateUpdate, OnRttUpdate, OnLossNotification): Rate updates are only forwarded to sub-encoders that have already been initialized. The latest RateControlParameters is also stashed so it can be applied when a sub-encoder lazily initializes. This avoids calling rate methods on an uninitialized encoder (which would be a no-op at best and a crash at worst), while still ensuring any sub-encoder that wakes up mid-stream starts with current bitrate state.
* Callback registration (RegisterEncodeCompleteCallback): The same callback is registered with both sub-encoders. Both paths emit EncodedImage objects through the same interface, so there's no conflict — whichever encoder produces output calls the callback, and the WebRTC stack doesn't care which path it came from.
* GetEncoderInfo: Reports supports_native_handle = true unconditionally, because the HybridVideoEncoder as a whole accepts native frames (it routes them to the passthrough sub-encoder). The base info is taken from the raw encoder when available, since that's the more complete descriptor (the builtin factory populates resolution scaling capabilities, scalability modes, etc.).
* GetSupportedFormats: Merges formats from both factories with deduplication by name + parameters. In practice, both factories advertise the same codecs (H.264, VP8, VP9), so most entries will be deduplicated. The merge ensures no format is omitted if one factory supports something the other doesn't.
* QueryVideoEncoder: Delegates to the builtin factory but forces has_internal_source = false. The passthrough encoder does technically have an "internal source" in OWT's model (the VideoEncoderInterface pulled from the native handle), but from WebRTC's perspective this flag controls whether the encoder bypasses the capture pipeline. Leaving it true could cause WebRTC to skip frame delivery, which would break the raw path. Forcing false keeps both paths live.

## What Isn't Handled
* If a stream transitions from encoded frames to raw frames (or vice versa) mid-session, both sub-encoders remain initialized after their first use. This is intentional — there's no mechanism to tear one down and rebuild the other on the fly, and in practice sources don't switch types mid-stream.
* The encoded_encoder_ is always created from EncodedVideoEncoderFactory even for streams that will only ever send raw frames. The encoder object is cheap to construct; it just isn't initialized until needed.