### PR TITLE
Limit DrainPendingStreams for encoded streams until signaling is stable

### DIFF
--- a/talk/owt/sdk/include/cpp/owt/base/stream.h
+++ b/talk/owt/sdk/include/cpp/owt/base/stream.h
@@ -274,6 +274,15 @@ class LocalStream : public Stream {
                        std::unique_ptr<LocalScreenStreamObserver> observer);
 #endif
 
+ public:
+  bool IsEncoded() const {
+#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
+    return encoded_;
+#else
+    return false;
+#endif
+  }
+
  private:
 #if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
   bool encoded_ = false;

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -254,7 +254,14 @@ void P2PPeerConnectionChannel::Publish(
   if (on_success) {
     on_success();
   }
-  DrainPendingStreams();
+  // For encoded (packet passthrough) streams, defer AddTrack() until signaling
+  // is stable. Calling AddTrack() during have-local-offer breaks the video
+  // send stream setup and AddOrUpdateSink is never called on the video source.
+  // OnSignalingChange(kStable) will call DrainPendingStreams() once stable.
+  if (!stream->IsEncoded() ||
+      temp_pc_->signaling_state() == webrtc::PeerConnectionInterface::kStable) {
+    DrainPendingStreams();
+  }
 }
 void P2PPeerConnectionChannel::Send(
     const std::string& message,
@@ -612,7 +619,12 @@ void P2PPeerConnectionChannel::OnSignalingChange(
         pending_remote_sdp_.reset();
         peer_connection_->SetRemoteDescription(std::move(new_desc), observer);
       } else {
-        DrainPendingStreams();
+        // Post DrainPendingStreams asynchronously so AddTrack() is not called
+        // from within the WebRTC signaling callback. Calling AddTrack() from
+        // within OnSignalingChange causes WebRTC to produce an offer with an
+        // empty a=msid-semantic, preventing the video send stream from being
+        // activated (AddOrUpdateSink never called on the video source).
+        event_queue_->PostTask([this] { DrainPendingStreams(); });
       }
       DrainPendingRemoteCandidates();
       break;


### PR DESCRIPTION
# Summary

When publishing an encoded (packet passthrough) stream, the first stream switch
could hang because `AddTrack()` was being called at the wrong moment in the WebRTC
signaling state machine. This fix defers `DrainPendingStreams()` for encoded streams
until signaling is stable.

# Details

WebRTC's `PeerConnectionInterface::AddTrack()` must not be called while signaling is
in `have-local-offer`. When it is, the resulting offer contains an empty
`a=msid-semantic` line, which prevents the browser from activating the video send
stream — `AddOrUpdateSink` is never called on the video source, so no frames flow.

The `HybridVideoEncoder` (introduced in PR #44) handles both raw and encoded
frames in the same peer connection by dispatching on `VideoFrameBuffer::Type::kNative`.
Encoded (`LocalEncodedCaptureTrackSource`) streams still set `encoded_ = true` on
`LocalStream`, so the existing `IsEncoded()` check is the right guard.

## Changes

* **`LocalStream::IsEncoded()`** (`stream.h`): Exposes the private `encoded_` flag as
  a public method so call sites can query whether a stream uses encoded passthrough frames.

* **`Publish()` guard** (`p2ppeerconnectionchannel.cc`): For encoded streams,
  `DrainPendingStreams()` is skipped if signaling is not yet `kStable`. The drain
  will happen via `OnSignalingChange(kStable)` once the offer/answer exchange finishes.
  Raw streams are unaffected — they drain immediately as before.

* **Async drain in `OnSignalingChange(kStable)`** (`p2ppeerconnectionchannel.cc`):
  `DrainPendingStreams()` is now posted to `event_queue_` instead of being called
  synchronously inside the signaling callback. Calling `AddTrack()` synchronously
  from within `OnSignalingChange` causes a re-entrant SDP mutation that produces the
  same broken offer as above.

# Notes

* Raw streams (camera, CPU inference) are not affected; they drain immediately in
  `Publish()` as before.
* This fix applies to both the old single-encoder path (`EncodedVideoEncoderFactory`)
  and the new `DualVideoEncoder` / `HybridVideoEncoder` path — the guard is keyed
  on whether the stream is encoded, not on which factory is active.
* The `encoded_` flag is set in `stream.cc` when a `LocalStream` is constructed with
  a `LocalEncodedCaptureTrackSource` (i.e. recorded passthrough mode). It is `false`
  for all other stream types.
