### PR TITLE
feat(webrtc): node-config-gated video-wall BWE/temporal tuning

### DIFF
--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -10,6 +10,7 @@ bool GlobalConfiguration::hardware_acceleration_enabled_ = true;
 #endif
 bool GlobalConfiguration::encoded_frame_ = false;
 bool GlobalConfiguration::dual_video_encoder_ = false;
+bool GlobalConfiguration::video_wall_bwe_tuning_enabled_ = false;
 std::unique_ptr<AudioFrameGeneratorInterface>
     GlobalConfiguration::audio_frame_generator_ = nullptr;
 std::unique_ptr<VideoDecoderInterface>

--- a/talk/owt/sdk/base/peerconnectionchannel.cc
+++ b/talk/owt/sdk/base/peerconnectionchannel.cc
@@ -3,12 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "talk/owt/sdk/base/peerconnectionchannel.h"
 #include <vector>
+#include "owt/base/globalconfiguration.h"
 #include "talk/owt/sdk/base/sdputils.h"
 #include "webrtc/rtc_base/logging.h"
 #include "webrtc/rtc_base/thread.h"
 using namespace rtc;
 namespace owt {
 namespace base {
+
+// EXPERIMENT (video-wall BWE/temporal scalability). Applied to every video
+// sender in ApplyBitrateSettings():
+//   #1 min_bitrate_bps  -> floor so the allocator can't starve a wall tile to ~0
+//   #1 bitrate_priority -> equal weight so spare bandwidth splits fairly
+//   #2 num_temporal_layers -> builtin H.264 encoder produces a temporal hierarchy
+//      and drops the top layer (lower fps) under BWE pressure instead of freezing.
+// Tunable; flag-gate or remove after validation.
+static constexpr int kVideoMinBitrateBps = 500000;     // 500 kbps per stream
+static constexpr double kVideoBitratePriority = 1.0;   // equal across tiles
+static constexpr int kVideoNumTemporalLayers = 3;
 PeerConnectionChannel::PeerConnectionChannel(
     PeerConnectionChannelConfiguration configuration)
     : configuration_(configuration),
@@ -54,30 +66,66 @@ void PeerConnectionChannel::ApplyBitrateSettings() {
   }
   for (auto sender : senders) {
     auto sender_track = sender->track();
-    if (sender_track != nullptr) {
-      webrtc::RtpParameters rtp_parameters = sender->GetParameters();
-      for (size_t idx = 0; idx < rtp_parameters.encodings.size(); idx++) {
-        // TODO(jianlin): It may not be appropriate to set the same settings
-        // on all encodings. Update the logic when upstream implement the
-        // the per codec settings, and many other encoding specific setttings
-        // should move here instead of modifying SDP.
-        if (sender_track->kind() ==
-            webrtc::MediaStreamTrackInterface::kAudioKind) {
-          if (configuration_.audio.size() > 0 &&
-              configuration_.audio[0].max_bitrate > 0) {
-            rtp_parameters.encodings[idx].max_bitrate_bps =
-                absl::optional<int>(configuration_.audio[0].max_bitrate * 1024);
-            sender->SetParameters(rtp_parameters);
-          }
-        } else if (sender_track->kind() ==
-                   webrtc::MediaStreamTrackInterface::kVideoKind) {
-          if (configuration_.video.size() > 0 &&
-              configuration_.video[0].max_bitrate > 0) {
-            rtp_parameters.encodings[idx].max_bitrate_bps =
-                absl::optional<int>(configuration_.video[0].max_bitrate * 1024);
-            sender->SetParameters(rtp_parameters);
-          }
+    if (sender_track == nullptr) {
+      continue;
+    }
+    webrtc::RtpParameters rtp_parameters = sender->GetParameters();
+    const bool is_audio =
+        sender_track->kind() == webrtc::MediaStreamTrackInterface::kAudioKind;
+    const bool is_video =
+        sender_track->kind() == webrtc::MediaStreamTrackInterface::kVideoKind;
+    bool modified = false;
+    for (size_t idx = 0; idx < rtp_parameters.encodings.size(); idx++) {
+      // TODO(jianlin): It may not be appropriate to set the same settings
+      // on all encodings. Update the logic when upstream implement the
+      // the per codec settings, and many other encoding specific setttings
+      // should move here instead of modifying SDP.
+      if (is_audio) {
+        if (configuration_.audio.size() > 0 &&
+            configuration_.audio[0].max_bitrate > 0) {
+          rtp_parameters.encodings[idx].max_bitrate_bps =
+              absl::optional<int>(configuration_.audio[0].max_bitrate * 1024);
+          modified = true;
         }
+      } else if (is_video) {
+        // Original behavior: apply the configured max bitrate (if any).
+        if (configuration_.video.size() > 0 &&
+            configuration_.video[0].max_bitrate > 0) {
+          rtp_parameters.encodings[idx].max_bitrate_bps =
+              absl::optional<int>(configuration_.video[0].max_bitrate * 1024);
+          modified = true;
+        }
+        // Gated by node config (enable_video_wall_bwe_tuning): apply the
+        // BWE floor, equal priority, and temporal layers to every video
+        // encoding so wall tiles degrade gracefully under congestion instead
+        // of starving/freezing. See the kVideo* constants above.
+        if (owt::base::GlobalConfiguration::GetVideoWallBweTuningEnabled()) {
+          rtp_parameters.encodings[idx].min_bitrate_bps =
+              absl::optional<int>(kVideoMinBitrateBps);
+          rtp_parameters.encodings[idx].bitrate_priority =
+              kVideoBitratePriority;
+          rtp_parameters.encodings[idx].num_temporal_layers =
+              kVideoNumTemporalLayers;
+          modified = true;
+        }
+      }
+    }
+    if (modified) {
+      webrtc::RTCError error = sender->SetParameters(rtp_parameters);
+      // NB: logged at LS_ERROR on purpose — this build filters RTC_LOG below
+      // LS_ERROR, so LS_INFO/LS_WARNING never reach webrtc_server.log.
+      if (!error.ok()) {
+        RTC_LOG(LS_ERROR) << "[BWE] SetParameters failed for "
+                          << (is_video ? "video" : "audio")
+                          << " sender: " << error.message();
+      } else if (is_video &&
+                 owt::base::GlobalConfiguration::GetVideoWallBweTuningEnabled()) {
+        RTC_LOG(LS_ERROR)
+            << "[BWE] applied video RTP params: min_bitrate_bps="
+            << kVideoMinBitrateBps
+            << " bitrate_priority=" << kVideoBitratePriority
+            << " num_temporal_layers=" << kVideoNumTemporalLayers
+            << " encodings=" << rtp_parameters.encodings.size();
       }
     }
   }

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -146,6 +146,18 @@ class GlobalConfiguration {
   static void SetNSEnabled(bool enabled) {
     audio_processing_settings_.NSEnabled = enabled;
   }
+  /**
+  @brief Enable/disable the video-wall BWE + temporal-scalability tuning applied
+  in PeerConnectionChannel::ApplyBitrateSettings() (per-stream min-bitrate floor,
+  equal bitrate priority, temporal layers). Off by default. Public getter so the
+  channel can read it without a friend declaration.
+  */
+  static void SetVideoWallBweTuningEnabled(bool enabled) {
+    video_wall_bwe_tuning_enabled_ = enabled;
+  }
+  static bool GetVideoWallBweTuningEnabled() {
+    return video_wall_bwe_tuning_enabled_;
+  }
  private:
   GlobalConfiguration() {}
   virtual ~GlobalConfiguration() {}
@@ -240,6 +252,8 @@ class GlobalConfiguration {
    * supports both raw and encoded video frames.
    */
   static bool dual_video_encoder_;
+  // Gates the video-wall BWE/temporal tuning in ApplyBitrateSettings(). Default false.
+  static bool video_wall_bwe_tuning_enabled_;
   static std::unique_ptr<AudioFrameGeneratorInterface> audio_frame_generator_;
   /**
    @brief This function returns flag indicating whether customized video decoder is enabled or not

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1176,6 +1176,12 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
         track_sources.append(track_info);
         temp_pc_->AddTrack(track, {stream_id});
       }
+      // EXPERIMENT: apply the BWE floor / equal priority / temporal layers now
+      // that the published track's sender exists. The original call site
+      // (OnSetLocalSessionDescriptionSuccess) never fires in this publish flow,
+      // so ApplyBitrateSettings() must run here, right after the deferred
+      // AddTrack(), or the encoding params are never applied.
+      ApplyBitrateSettings();
       // The second signaling message of track sources to remote peer.
       Json::Value json_track_sources;
       json_track_sources[kMessageTypeKey] = kChatTrackSources;


### PR DESCRIPTION
## What
Node-config-gated tuning in `webrtc_server`'s `ApplyBitrateSettings()` to address video-wall frame drops under congestion.

When `GlobalConfiguration::GetVideoWallBweTuningEnabled()` is true, every video sender encoding gets:
- `min_bitrate_bps = 500_000` — a per-stream floor.
- `bitrate_priority = 1.0` — equal share across tiles.
- `num_temporal_layers = 3` — request a temporal hierarchy from the builtin H.264 encoder.

Also calls `ApplyBitrateSettings()` from `DrainPendingStreams()` (publish path) so the params apply to the appliance's raw-frame publications. **Off by default.**

The flag is plumbed from the appliance node config (`enable_video_wall_bwe_tuning`) into `GlobalConfiguration` at startup — see the companion appliance PR.

## Why
A video wall is one PeerConnection with N tracks sharing a single GCC estimate; the intent of the floor + equal priority + temporal layers is to let tiles degrade gracefully (drop the top temporal layer) rather than starve/freeze when the shared estimate drops.

## What was verified locally
- Flag ON → the three params are applied to each video sender; `SetParameters` accepted `num_temporal_layers=3` at runtime (logged: `applied video RTP params: min_bitrate_bps=500000 bitrate_priority=1 num_temporal_layers=3`).
- Flag OFF → no params applied while streams were actively flowing (gate suppresses; default behavior preserved).
- End-to-end flag delivery confirmed: portal node config → config_manager → `/tmp/cached-config.yml` → `webrtc_server` (`CACHED_CONFIG_PATH`) → `GlobalConfiguration`.

Not yet measured on this gated build: the runtime effect on the BWE estimate / framerate under load (the floor's congestion behavior). That needs a before/after capture under the jitter sim.

## Note for reviewers
The `[BWE]` `RTC_LOG` lines are diagnostic, logged at `LS_ERROR` only to bypass the appliance's RTC severity filter (`Logging::Severity(kError)`). Lower the level or remove before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)