### PR TITLE
Add flag to set min bitrate stting and tile priority for better BWE of video walls.

### DIFF
--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -10,6 +10,7 @@ bool GlobalConfiguration::hardware_acceleration_enabled_ = true;
 #endif
 bool GlobalConfiguration::encoded_frame_ = false;
 bool GlobalConfiguration::dual_video_encoder_ = false;
+bool GlobalConfiguration::bwe_optimization_settings_enabled_ = false;
 std::unique_ptr<AudioFrameGeneratorInterface>
     GlobalConfiguration::audio_frame_generator_ = nullptr;
 std::unique_ptr<VideoDecoderInterface>

--- a/talk/owt/sdk/base/peerconnectionchannel.cc
+++ b/talk/owt/sdk/base/peerconnectionchannel.cc
@@ -4,11 +4,14 @@
 #include "talk/owt/sdk/base/peerconnectionchannel.h"
 #include <vector>
 #include "talk/owt/sdk/base/sdputils.h"
+#include "owt/base/globalconfiguration.h"
 #include "webrtc/rtc_base/logging.h"
 #include "webrtc/rtc_base/thread.h"
 using namespace rtc;
 namespace owt {
 namespace base {
+static constexpr int kBweOptimizationSettingsMinBitrateBps = 500000;  // 500 kbps
+static constexpr double kVideoBitratePriority = 1.0;                  // Equal across all tiles
 PeerConnectionChannel::PeerConnectionChannel(
     PeerConnectionChannelConfiguration configuration)
     : configuration_(configuration),
@@ -54,30 +57,42 @@ void PeerConnectionChannel::ApplyBitrateSettings() {
   }
   for (auto sender : senders) {
     auto sender_track = sender->track();
-    if (sender_track != nullptr) {
-      webrtc::RtpParameters rtp_parameters = sender->GetParameters();
-      for (size_t idx = 0; idx < rtp_parameters.encodings.size(); idx++) {
-        // TODO(jianlin): It may not be appropriate to set the same settings
-        // on all encodings. Update the logic when upstream implement the
-        // the per codec settings, and many other encoding specific setttings
-        // should move here instead of modifying SDP.
-        if (sender_track->kind() ==
-            webrtc::MediaStreamTrackInterface::kAudioKind) {
-          if (configuration_.audio.size() > 0 &&
-              configuration_.audio[0].max_bitrate > 0) {
-            rtp_parameters.encodings[idx].max_bitrate_bps =
-                absl::optional<int>(configuration_.audio[0].max_bitrate * 1024);
-            sender->SetParameters(rtp_parameters);
-          }
-        } else if (sender_track->kind() ==
-                   webrtc::MediaStreamTrackInterface::kVideoKind) {
-          if (configuration_.video.size() > 0 &&
-              configuration_.video[0].max_bitrate > 0) {
-            rtp_parameters.encodings[idx].max_bitrate_bps =
-                absl::optional<int>(configuration_.video[0].max_bitrate * 1024);
-            sender->SetParameters(rtp_parameters);
-          }
+    if (sender_track == nullptr) {
+      continue;
+    }
+    webrtc::RtpParameters rtp_parameters = sender->GetParameters();
+    bool is_audio = sender_track->kind() == webrtc::MediaStreamTrackInterface::kAudioKind;
+    bool is_video = sender_track->kind() == webrtc::MediaStreamTrackInterface::kVideoKind;
+    for (size_t idx = 0; idx < rtp_parameters.encodings.size(); idx++) {  
+      // TODO(jianlin): It may not be appropriate to set the same settings
+      // on all encodings. Update the logic when upstream implement the
+      // the per codec settings, and many other encoding specific setttings
+      // should move here instead of modifying SDP.
+      bool is_modified = false;
+      if (is_audio) {
+        if (configuration_.audio.size() > 0 &&
+            configuration_.audio[0].max_bitrate > 0) {
+          rtp_parameters.encodings[idx].max_bitrate_bps =
+              absl::optional<int>(configuration_.audio[0].max_bitrate * 1024);
+          is_modified = true;
         }
+      } else if (is_video) {
+        if (configuration_.video.size() > 0 &&
+            configuration_.video[0].max_bitrate > 0) {
+          rtp_parameters.encodings[idx].max_bitrate_bps =
+              absl::optional<int>(configuration_.video[0].max_bitrate * 1024);
+          is_modified = true;
+        }
+        // Gated by node config flag, if enabled, set the min bitrate and priority.
+        if (GlobalConfiguration::GetBweOptimizationSettingsEnabled()) {
+          rtp_parameters.encodings[idx].min_bitrate_bps =
+              absl::optional<int>(kBweOptimizationSettingsMinBitrateBps);
+          rtp_parameters.encodings[idx].bitrate_priority = kVideoBitratePriority;
+          is_modified = true;
+        }
+      }
+      if (is_modified) {
+        sender->SetParameters(rtp_parameters);
       }
     }
   }

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -74,6 +74,21 @@ class GlobalConfiguration {
     dual_video_encoder_ = enabled;
   }
   /**
+   @brief This function sets the optimization flags for the peer connection, which
+   helps improve the performance of video walls.
+   @param enabled Optimization flags are enabled or not.
+   */
+  static void SetBweOptimizationSettingsEnabled(bool enabled) {
+    bwe_optimization_settings_enabled_ = enabled;
+  }
+  /**
+   @brief This function gets whether the BWE optimization settings are enabled or not.
+   @return true or false.
+   */
+  static bool GetBweOptimizationSettingsEnabled() {
+    return bwe_optimization_settings_enabled_;
+  }
+  /**
    @brief This function sets the audio input to be an instance of
    AudioFrameGeneratorInterface.
    @details When it is enabled, SDK will not capture audio from mic. This means
@@ -240,6 +255,10 @@ class GlobalConfiguration {
    * supports both raw and encoded video frames.
    */
   static bool dual_video_encoder_;
+  /**
+   * Default is false. If it is set to true, uses BWE optimization settings.
+   */
+  static bool bwe_optimization_settings_enabled_;
   static std::unique_ptr<AudioFrameGeneratorInterface> audio_frame_generator_;
   /**
    @brief This function returns flag indicating whether customized video decoder is enabled or not


### PR DESCRIPTION
# Summary
A video wall is one PeerConnection with N tracks sharing a single GCC estimate; the intent of the floor + equal priority is to let tiles degrade gracefully (drop the top temporal layer) rather than starve/freeze when the shared estimate drops.

# Test
* Flag ON → the three params are applied to each video sender; (logged: applied video RTP params: min_bitrate_bps=500000 bitrate_priority=1). Smoother video and faster actual bitrate sent by webrtc.
* Flag OFF → no params applied while streams were actively flowing (gate suppresses; default behavior preserved).
* End-to-end flag delivery confirmed: portal node config → config_manager → /tmp/cached-config.yml → webrtc_server (CACHED_CONFIG_PATH) → GlobalConfiguration.