### PR TITLE
Logs for every ICE pair selection and change in between

### DIFF
--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -788,6 +788,29 @@ void P2PPeerConnectionChannel::OnIceCandidate(
   json[kMessageDataKey] = signal;
   SendSignalingMessage(json);
 }
+// AMBIENT: Fires when ICE nominates a candidate pair, and again whenever the
+// selected pair changes mid-call (e.g. srflx -> relay failover). This is the
+// only place that reports the path media is ACTUALLY using; GetConnectionStats
+// gives a snapshot, this gives the transitions. remote_id_ is the peerid.
+// Candidate::type() uses WebRTC internal names: local(host)/stun(srflx)/relay/prflx.
+// LS_ERROR (not LS_INFO): the appliance sets owt log severity to kError, so
+// INFO/WARNING are filtered out. Log at ERROR so this always emits.
+void P2PPeerConnectionChannel::OnIceSelectedCandidatePairChanged(
+    const cricket::CandidatePairChangeEvent& event) {
+  const cricket::Candidate& local = event.selected_candidate_pair.local;
+  const cricket::Candidate& remote = event.selected_candidate_pair.remote;
+  RTC_LOG(LS_ERROR) << "[ICE] selected_pair_changed"
+                    << " peerid=" << remote_id_
+                    << " local_type=" << local.type()
+                    << " remote_type=" << remote.type()
+                    << " local_protocol=" << local.protocol()
+                    << " remote_relay_protocol=" << remote.relay_protocol()
+                    << " is_relay="
+                    << ((local.type() == "relay" || remote.type() == "relay")
+                            ? "true"
+                            : "false")
+                    << " reason=" << event.reason;
+}
 void P2PPeerConnectionChannel::OnCreateSessionDescriptionSuccess(
     webrtc::SessionDescriptionInterface* desc) {
   RTC_LOG(LS_INFO) << "Create sdp success.";

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -123,6 +123,10 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   virtual void OnIceGatheringChange(
       PeerConnectionInterface::IceGatheringState new_state) override;
   virtual void OnIceCandidate(const webrtc::IceCandidateInterface* candidate) override;
+  // AMBIENT: log the selected ICE candidate pair (host/srflx/relay) and every
+  // mid-call change, so we can see which path media actually used per peer.
+  virtual void OnIceSelectedCandidatePairChanged(
+      const cricket::CandidatePairChangeEvent& event) override;
   virtual void OnRenegotiationNeeded() override;
   // DataChannelObserver
   virtual void OnDataChannelStateChange() override;


### PR DESCRIPTION
Adds an OnIceSelectedCandidatePairChanged override on P2PPeerConnectionChannel that logs which ICE candidate pair a connection actually uses — local/remote types (host/srflx/relay), protocols, an is_relay flag, and the change reason — keyed by remote_id_ (peerid).

It fires on initial nomination and on every mid-call pair change (e.g. srflx→relay failover), so we can see when a connection is relay-bound — the case where media never arrives despite a successful publish, even though signaling looks healthy.

Logged at LS_ERROR because the appliance sets owt log severity to kError, which filters out INFO/WARNING.

Observability only — no behavior change.

Sample log:


[ICE] selected_pair_changed peerid=<uuid>:user@acct.com local_type=relay remote_type=stun local_protocol=udp is_relay=true reason=candidate pair state changed

Tested it on stackmod
<img width="970" height="136" alt="Screenshot 2026-06-23 at 6 23 01 PM" src="https://github.com/user-attachments/assets/1cd9ef21-ccaf-4182-a0d7-cd8b52dede10" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only callback with no changes to ICE handling or media paths; extra ERROR lines may add noise in production logs.
> 
> **Overview**
> Adds **`OnIceSelectedCandidatePairChanged`** on `P2PPeerConnectionChannel` so each P2P session logs when WebRTC nominates or switches the active ICE pair (initial connect and mid-call failover, e.g. srflx → relay).
> 
> Each line includes **`peerid`** (`remote_id_`), local/remote candidate types, protocols, an **`is_relay`** flag, and the change **reason**. Logging uses **`LS_ERROR`** so lines appear when the appliance runs OWT at error-only severity.
> 
> Observability only — no signaling, media, or connection logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da42da306b48066c3a3d66a3b54e88776604b720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->