### PR TITLE
connection lifecycle logs

### DIFF
--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -167,7 +167,7 @@ void P2PPeerConnectionChannel::Publish(
     std::shared_ptr<LocalStream> stream,
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Publishing a local stream. peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=Publishing a local stream. peerid=" << remote_id_
                    << " session_state=" << session_state_;
   // Add reference to peer connection until end of function.
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
@@ -251,7 +251,7 @@ void P2PPeerConnectionChannel::Publish(
     std::lock_guard<std::mutex> lock(published_streams_mutex_);
     publishing_streams_.insert(stream_label);
   }
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] stream_queued_for_publish peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=stream_queued_for_publish peerid=" << remote_id_
                    << " session_state=" << session_state_
                    << " pending_streams=" << pending_publish_streams_.size();
   if (on_success) {
@@ -339,7 +339,7 @@ void P2PPeerConnectionChannel::CreateOffer() {
     }
   }
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] create_offer peerid=" << remote_id_;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=create_offer peerid=" << remote_id_;
   negotiation_needed_ = false;
   scoped_refptr<FunctionalCreateSessionDescriptionObserver> observer =
       FunctionalCreateSessionDescriptionObserver::Create(
@@ -355,7 +355,7 @@ void P2PPeerConnectionChannel::CreateOffer() {
   }
 }
 void P2PPeerConnectionChannel::CreateAnswer() {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] create_answer peerid=" << remote_id_;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=create_answer peerid=" << remote_id_;
   // Get reference so peer_connection_ is not deleted before calling CreateAnswer
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   scoped_refptr<FunctionalCreateSessionDescriptionObserver> observer =
@@ -405,7 +405,7 @@ void P2PPeerConnectionChannel::OnIncomingSignalingMessage(
     RTC_LOG(LS_WARNING) << "Cannot get type from incoming message.";
     return;
   }
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] incoming_message peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=incoming_message peerid=" << remote_id_
                     << " msg_type=" << message_type;
   if (message_type == kChatUserAgent) {
     // Send back user agent info once and only once
@@ -444,7 +444,7 @@ void P2PPeerConnectionChannel::OnIncomingSignalingMessage(
   }
 }
 void P2PPeerConnectionChannel::OnMessageUserAgent(Json::Value& ua) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] ua_received peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=ua_received peerid=" << remote_id_
                    << " session_state=" << session_state_;
   HandleRemoteCapability(ua);
   switch (session_state_) {
@@ -458,7 +458,7 @@ void P2PPeerConnectionChannel::OnMessageUserAgent(Json::Value& ua) {
   }
 }
 void P2PPeerConnectionChannel::OnMessageStop() {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Remote user stopped. peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=Remote user stopped. peerid=" << remote_id_
                    << " session_state=" << session_state_;
   ClosePeerConnection();
   ChangeSessionState(kSessionStateReady);
@@ -467,7 +467,7 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
   string type;
   string desc;
   rtc::GetStringFromJsonObject(message, kSessionDescriptionTypeKey, &type);
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] signal_received peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=signal_received peerid=" << remote_id_
                    << " msg_type=" << type
                    << " session_state=" << session_state_;
   // Store reference so peer_connection_ is not deleted until function ends
@@ -490,12 +490,12 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
     std::unique_ptr<webrtc::SessionDescriptionInterface> desc(
         webrtc::CreateSessionDescription(type, sdp, nullptr));
     if (!desc) {
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Failed to create session description. peerid=" << remote_id_
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=Failed to create session description. peerid=" << remote_id_
                         << " msg_type=" << type;
       return;
     }
     if (type == "offer" && temp_pc_ && temp_pc_->signaling_state() != webrtc::PeerConnectionInterface::kStable) {
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG] sdp_offer_queued peerid=" << remote_id_
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=sdp_offer_queued peerid=" << remote_id_
                         << " signaling_state=" << static_cast<int>(temp_pc_->signaling_state());
       pending_remote_sdp_ = std::move(desc);
     } else {
@@ -505,7 +505,7 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
               std::placeholders::_1));
       std::string sdp_string;
       if (!desc->ToString(&sdp_string)) {
-        RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Error parsing local description. peerid=" << remote_id_
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=Error parsing local description. peerid=" << remote_id_
                           << " msg_type=" << type;
         RTC_DCHECK(false);
       }
@@ -523,13 +523,13 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
           webrtc::CreateSessionDescription(desc->type(), sdp_string, nullptr));
       // Synchronous call. After done, will invoke OnSetRemoteDescription. If
       // remote sent an offer, we create answer for it.
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG] set_remote_description peerid=" << remote_id_
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=set_remote_description peerid=" << remote_id_
                        << " msg_type=" << type;
       temp_pc_->SetRemoteDescription(std::move(new_desc), observer);
       pending_remote_sdp_.reset();
     }
   } else if (type == "candidates") {
-    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] remote_candidate_received peerid=" << remote_id_;
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=remote_candidate_received peerid=" << remote_id_;
     string sdp_mid;
     string candidate;
     int sdp_mline_index;
@@ -554,7 +554,7 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
 }
 void P2PPeerConnectionChannel::OnMessageTracksAdded(
     Json::Value& stream_tracks) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] tracks_added_ack peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=tracks_added_ack peerid=" << remote_id_
                    << " track_count=" << stream_tracks.size();
   // Find the streams with track information, and add them to published stream
   // list.
@@ -600,7 +600,7 @@ void P2PPeerConnectionChannel::OnSignalingChange(
     "kStable","kHaveLocalOffer","kHaveLocalPrAnswer","kHaveRemoteOffer","kHaveRemotePrAnswer","kClosed"
   };
   const char* state_name = (new_state >= 0 && new_state <= 5) ? kSigStateNames[new_state] : "unknown";
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] signaling_state peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=signaling_state peerid=" << remote_id_
                    << " state=" << state_name << " (" << new_state << ")";
 
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
@@ -613,14 +613,14 @@ void P2PPeerConnectionChannel::OnSignalingChange(
   switch (new_state) {
     case PeerConnectionInterface::SignalingState::kStable:
       if (pending_remote_sdp_) {
-        RTC_LOG(LS_ERROR) << "[CONN-DIAG] retrying_queued_sdp peerid=" << remote_id_;
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=retrying_queued_sdp peerid=" << remote_id_;
         scoped_refptr<FunctionalSetRemoteDescriptionObserver> observer =
             FunctionalSetRemoteDescriptionObserver::Create(std::bind(
                 &P2PPeerConnectionChannel::OnSetRemoteDescriptionComplete, this,
                 std::placeholders::_1));
         std::string sdp_string;
         if (!pending_remote_sdp_->ToString(&sdp_string)) {
-          RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Error parsing local description. peerid=" << remote_id_
+          RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=Error parsing local description. peerid=" << remote_id_
                             << " msg_type=queued_offer";
           RTC_DCHECK(false);
         }
@@ -715,7 +715,7 @@ void P2PPeerConnectionChannel::OnDataChannel(
 void P2PPeerConnectionChannel::OnNegotiationNeeded() {
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_neg_ = GetPeerConnectionRef();
   int sig_state = temp_pc_neg_ ? static_cast<int>(temp_pc_neg_->signaling_state()) : -1;
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] negotiation_needed peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=negotiation_needed peerid=" << remote_id_
                    << " signaling_state=" << sig_state;
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   if (temp_pc_ && temp_pc_->signaling_state() == PeerConnectionInterface::SignalingState::kStable) {
@@ -725,7 +725,7 @@ void P2PPeerConnectionChannel::OnNegotiationNeeded() {
   }
 }
 void P2PPeerConnectionChannel::OnRenegotiationNeeded() {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] renegotiation_needed peerid=" << remote_id_;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=renegotiation_needed peerid=" << remote_id_;
   CreateOffer();
 }
 
@@ -735,7 +735,7 @@ void P2PPeerConnectionChannel::OnIceConnectionChange(
     "New","Checking","Connected","Completed","Failed","Disconnected","Closed","Max"
   };
   const char* ice_conn_name = (new_state >= 0 && new_state <= 7) ? kIceConnStateNames[new_state] : "unknown";
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] IceConnectionState peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=IceConnectionState peerid=" << remote_id_
                    << " state=" << ice_conn_name << " (" << new_state << ")";
   switch (new_state) {
     case webrtc::PeerConnectionInterface::kIceConnectionConnected:
@@ -750,7 +750,7 @@ void P2PPeerConnectionChannel::OnIceConnectionChange(
       DrainPendingStreams();
       break;
     case webrtc::PeerConnectionInterface::kIceConnectionDisconnected:
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] disconnected peerid=" << remote_id_;
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=disconnected peerid=" << remote_id_;
       // {
       //   std::lock_guard<std::mutex> lock(last_disconnect_mutex_);
       //   last_disconnect_ = std::chrono::system_clock::now();
@@ -781,7 +781,7 @@ void P2PPeerConnectionChannel::OnIceConnectionChange(
       CleanLastPeerConnection();
       break;
     case webrtc::PeerConnectionInterface::kIceConnectionFailed:
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE][WARN] failed peerid=" << remote_id_
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE][WARN] event=ice_failed peerid=" << remote_id_
                         << " remote_streams_count=" << remote_streams_.size();
       for (std::unordered_map<std::string,
                               std::shared_ptr<RemoteStream>>::iterator it =
@@ -802,12 +802,12 @@ void P2PPeerConnectionChannel::OnIceGatheringChange(
     PeerConnectionInterface::IceGatheringState new_state) {
   static const char* kGatherStateNames[] = {"kIceGatheringNew","kIceGatheringGathering","kIceGatheringComplete"};
   const char* gs_name = (new_state >= 0 && new_state <= 2) ? kGatherStateNames[new_state] : "unknown";
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] gathering_state peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=gathering_state peerid=" << remote_id_
                    << " state=" << gs_name << " (" << new_state << ")";
 }
 void P2PPeerConnectionChannel::OnIceCandidate(
     const webrtc::IceCandidateInterface* candidate) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] local_candidate peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=local_candidate peerid=" << remote_id_
                    << " sdp_mid=" << candidate->sdp_mid()
                    << " type=" << candidate->candidate().type();
   Json::Value signal;
@@ -816,7 +816,7 @@ void P2PPeerConnectionChannel::OnIceCandidate(
   signal[kIceCandidateSdpMidKey] = candidate->sdp_mid();
   string sdp;
   if (!candidate->ToString(&sdp)) {
-    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE][ERROR] Failed to serialize candidate. peerid=" << remote_id_;
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE][ERROR] event=Failed to serialize candidate. peerid=" << remote_id_;
     return;
   }
   signal[kIceCandidateSdpNameKey] = sdp;
@@ -836,7 +836,7 @@ void P2PPeerConnectionChannel::OnIceSelectedCandidatePairChanged(
     const cricket::CandidatePairChangeEvent& event) {
   const cricket::Candidate& local = event.selected_candidate_pair.local;
   const cricket::Candidate& remote = event.selected_candidate_pair.remote;
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] selected_pair_changed peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=selected_pair_changed peerid=" << remote_id_
                     << " local=" << local.type() << "://" << local.address().ToString()
                     << " remote=" << remote.type() << "://" << remote.address().ToString()
                     << " local_protocol=" << local.protocol()
@@ -849,7 +849,7 @@ void P2PPeerConnectionChannel::OnIceSelectedCandidatePairChanged(
 }
 void P2PPeerConnectionChannel::OnCreateSessionDescriptionSuccess(
     webrtc::SessionDescriptionInterface* desc) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] sdp_created peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=sdp_created peerid=" << remote_id_
                    << " type=" << desc->type();
   {
     std::lock_guard<std::mutex> lock(ended_mutex_);
@@ -867,12 +867,12 @@ void P2PPeerConnectionChannel::OnCreateSessionDescriptionSuccess(
 }
 void P2PPeerConnectionChannel::OnCreateSessionDescriptionFailure(
     const std::string& error) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Create sdp failed. peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=Create sdp failed. peerid=" << remote_id_
                    << " err=" << error;
   Stop(nullptr, nullptr);
 }
 void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionSuccess() {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] set_local_sdp_success peerid=" << remote_id_;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=set_local_sdp_success peerid=" << remote_id_;
   {
     std::lock_guard<std::mutex> lock(is_creating_offer_mutex_);
     is_creating_offer_ = false;
@@ -899,7 +899,7 @@ void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionSuccess() {
 }
 void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionFailure(
     const std::string& error) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Set local sdp failed. peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=Set local sdp failed. peerid=" << remote_id_
                    << " err=" << error;
   Stop(nullptr, nullptr);
 }
@@ -908,13 +908,13 @@ void P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionSuccess() {
     std::lock_guard<std::mutex> lock(ended_mutex_);
     if (ended_) { return; }
   }
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] set_remote_sdp_success peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=set_remote_sdp_success peerid=" << remote_id_
                    << " session_state=" << session_state_;
   PeerConnectionChannel::OnSetRemoteSessionDescriptionSuccess();
 }
 void P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionFailure(
     const std::string& error) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Set remote sdp failed. peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=Set remote sdp failed. peerid=" << remote_id_
                    << " err=" << error;
   std::cout << "Set remote_sdp FAILED" << std::endl << std::endl;
   Stop(nullptr, nullptr);
@@ -993,9 +993,9 @@ void P2PPeerConnectionChannel::Unpublish(
       //   on_failure(std::move(e));
       // }
       // return;
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG] Did not find published stream. peerid=" << remote_id_;
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=Did not find published stream. peerid=" << remote_id_;
     } else {
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG] Found published stream. peerid=" << remote_id_;
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=Found published stream. peerid=" << remote_id_;
       published_streams_.erase(it);
     }
   }
@@ -1011,7 +1011,7 @@ void P2PPeerConnectionChannel::Unpublish(
 void P2PPeerConnectionChannel::Stop(
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Stop called peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=stop_called peerid=" << remote_id_
                    << " session_state=" << session_state_;
   switch (session_state_) {
     case kSessionStateConnecting:
@@ -1152,7 +1152,7 @@ bool P2PPeerConnectionChannel::IsStale() {
                ((ice_state == webrtc::PeerConnectionInterface::kIceConnectionNew)
                 || ((ice_state == webrtc::PeerConnectionInterface::kIceConnectionFailed) &&
                    (signaling_state == webrtc::PeerConnectionInterface::kHaveLocalOffer)));
-    RTC_LOG(LS_ERROR) << "[CONN-DIAG] IsStale peerid=" << remote_id_
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=is_stale peerid=" << remote_id_
                       << " age_secs=" << age
                       << " ice_state=" << ice_state
                       << " signaling_state=" << signaling_state
@@ -1200,7 +1200,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       bool is_to_be_unpublished = false;
       for (auto& un_stream : unpublish_snapshot) {
         if (stream == un_stream) { // comparison of pointers;
-          RTC_LOG(LS_ERROR) << "[CONN-DIAG] Trying to Publish and Unpublish stream. peerid=" << remote_id_;
+          RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=Trying to Publish and Unpublish stream. peerid=" << remote_id_;
           is_to_be_unpublished = true;
           break;
         }
@@ -1298,7 +1298,7 @@ void P2PPeerConnectionChannel::SendStop(
 }
 // Only function that holds locks while calling WebRTC methods. Any deadlock is here.
 void P2PPeerConnectionChannel::ClosePeerConnection() {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] ClosePeerConnection peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=close_peer_connection peerid=" << remote_id_
                    << " already_ended=" << ended_;
   // Reference to peer connection  that outlives the scope of the locks.
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_;
@@ -1342,7 +1342,7 @@ void P2PPeerConnectionChannel::CheckWaitedList() {
 
 void P2PPeerConnectionChannel::OnDataChannelStateChange() {
   if (data_channel_) {
-    RTC_LOG(LS_ERROR) << "[CONN-DIAG] datachannel_state peerid=" << remote_id_
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=datachannel_state peerid=" << remote_id_
                      << " state=" << data_channel_->state();
     if (data_channel_->state() == webrtc::DataChannelInterface::DataState::kOpen) {
       DrainPendingMessages();
@@ -1431,7 +1431,7 @@ void P2PPeerConnectionChannel::DrainPendingRemoteCandidates() {
   // and pending remote candidates have already been cleared.
   if (temp_pc_ && temp_pc_->remote_description()) {
     rtc::CritScope cs(&pending_remote_candidates_crit_);
-    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] drain_pending_candidates peerid=" << remote_id_
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=drain_pending_candidates peerid=" << remote_id_
                       << " count=" << pending_remote_candidates_.size();
     for (const auto& ice_candidate : pending_remote_candidates_) {
       if (!temp_pc_->AddIceCandidate(ice_candidate.get())) {

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -167,7 +167,8 @@ void P2PPeerConnectionChannel::Publish(
     std::shared_ptr<LocalStream> stream,
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
-  RTC_LOG(LS_INFO) << "Publishing a local stream.";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Publishing a local stream. peerid=" << remote_id_
+                   << " session_state=" << session_state_;
   // Add reference to peer connection until end of function.
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   if (!temp_pc_) {
@@ -250,7 +251,9 @@ void P2PPeerConnectionChannel::Publish(
     std::lock_guard<std::mutex> lock(published_streams_mutex_);
     publishing_streams_.insert(stream_label);
   }
-  RTC_LOG(LS_INFO) << "Session state: " << session_state_;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] stream_queued_for_publish peerid=" << remote_id_
+                   << " session_state=" << session_state_
+                   << " pending_streams=" << pending_publish_streams_.size();
   if (on_success) {
     on_success();
   }
@@ -336,7 +339,7 @@ void P2PPeerConnectionChannel::CreateOffer() {
     }
   }
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
-  RTC_LOG(LS_INFO) << "Create offer.";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] create_offer peerid=" << remote_id_;
   negotiation_needed_ = false;
   scoped_refptr<FunctionalCreateSessionDescriptionObserver> observer =
       FunctionalCreateSessionDescriptionObserver::Create(
@@ -352,7 +355,7 @@ void P2PPeerConnectionChannel::CreateOffer() {
   }
 }
 void P2PPeerConnectionChannel::CreateAnswer() {
-  RTC_LOG(LS_INFO) << "Create answer.";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] create_answer peerid=" << remote_id_;
   // Get reference so peer_connection_ is not deleted before calling CreateAnswer
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   scoped_refptr<FunctionalCreateSessionDescriptionObserver> observer =
@@ -402,6 +405,8 @@ void P2PPeerConnectionChannel::OnIncomingSignalingMessage(
     RTC_LOG(LS_WARNING) << "Cannot get type from incoming message.";
     return;
   }
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] incoming_message peerid=" << remote_id_
+                    << " msg_type=" << message_type;
   if (message_type == kChatUserAgent) {
     // Send back user agent info once and only once
     {
@@ -439,6 +444,8 @@ void P2PPeerConnectionChannel::OnIncomingSignalingMessage(
   }
 }
 void P2PPeerConnectionChannel::OnMessageUserAgent(Json::Value& ua) {
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] ua_received peerid=" << remote_id_
+                   << " session_state=" << session_state_;
   HandleRemoteCapability(ua);
   switch (session_state_) {
     case kSessionStateReady:
@@ -451,16 +458,18 @@ void P2PPeerConnectionChannel::OnMessageUserAgent(Json::Value& ua) {
   }
 }
 void P2PPeerConnectionChannel::OnMessageStop() {
-  RTC_LOG(LS_INFO) << "Remote user stopped.";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Remote user stopped. peerid=" << remote_id_
+                   << " session_state=" << session_state_;
   ClosePeerConnection();
   ChangeSessionState(kSessionStateReady);
 }
 void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
-  RTC_LOG(LS_INFO) << "OnMessageSignal";
   string type;
   string desc;
   rtc::GetStringFromJsonObject(message, kSessionDescriptionTypeKey, &type);
-  RTC_LOG(LS_INFO) << "Received message type: " << type;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] signal_received peerid=" << remote_id_
+                   << " msg_type=" << type
+                   << " session_state=" << session_state_;
   // Store reference so peer_connection_ is not deleted until function ends
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   if (!temp_pc_) {
@@ -481,12 +490,13 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
     std::unique_ptr<webrtc::SessionDescriptionInterface> desc(
         webrtc::CreateSessionDescription(type, sdp, nullptr));
     if (!desc) {
-      RTC_LOG(LS_ERROR) << "Failed to create session description.";
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] Failed to create session description. peerid=" << remote_id_
+                        << " msg_type=" << type;
       return;
     }
     if (type == "offer" && temp_pc_ && temp_pc_->signaling_state() != webrtc::PeerConnectionInterface::kStable) {
-      RTC_LOG(LS_INFO) << "Signaling state is " << temp_pc_->signaling_state()
-                       << ", set SDP later.";
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] sdp_offer_queued peerid=" << remote_id_
+                        << " signaling_state=" << static_cast<int>(temp_pc_->signaling_state());
       pending_remote_sdp_ = std::move(desc);
     } else {
       scoped_refptr<FunctionalSetRemoteDescriptionObserver> observer =
@@ -495,7 +505,8 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
               std::placeholders::_1));
       std::string sdp_string;
       if (!desc->ToString(&sdp_string)) {
-        RTC_LOG(LS_ERROR) << "Error parsing local description.";
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] Error parsing local description. peerid=" << remote_id_
+                          << " msg_type=" << type;
         RTC_DCHECK(false);
       }
       std::vector<AudioCodec> audio_codecs;
@@ -512,11 +523,13 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
           webrtc::CreateSessionDescription(desc->type(), sdp_string, nullptr));
       // Synchronous call. After done, will invoke OnSetRemoteDescription. If
       // remote sent an offer, we create answer for it.
-      RTC_LOG(LS_WARNING) << "SetRemoteSdp:" << sdp_string;
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] set_remote_description peerid=" << remote_id_
+                       << " msg_type=" << type;
       temp_pc_->SetRemoteDescription(std::move(new_desc), observer);
       pending_remote_sdp_.reset();
     }
   } else if (type == "candidates") {
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] remote_candidate_received peerid=" << remote_id_;
     string sdp_mid;
     string candidate;
     int sdp_mline_index;
@@ -541,6 +554,8 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
 }
 void P2PPeerConnectionChannel::OnMessageTracksAdded(
     Json::Value& stream_tracks) {
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] tracks_added_ack peerid=" << remote_id_
+                   << " track_count=" << stream_tracks.size();
   // Find the streams with track information, and add them to published stream
   // list.
   for (Json::Value::ArrayIndex idx = 0; idx != stream_tracks.size(); idx++) {
@@ -581,7 +596,12 @@ void P2PPeerConnectionChannel::OnMessageStreamInfo(Json::Value& stream_info) {
 }
 void P2PPeerConnectionChannel::OnSignalingChange(
     PeerConnectionInterface::SignalingState new_state) {
-  RTC_LOG(LS_INFO) << "Signaling state changed: " << new_state;
+  static const char* kSigStateNames[] = {
+    "kStable","kHaveLocalOffer","kHaveLocalPrAnswer","kHaveRemoteOffer","kHaveRemotePrAnswer","kClosed"
+  };
+  const char* state_name = (new_state >= 0 && new_state <= 5) ? kSigStateNames[new_state] : "unknown";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] signaling_state peerid=" << remote_id_
+                   << " state=" << state_name << " (" << new_state << ")";
 
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   if (!temp_pc_) {
@@ -593,14 +613,15 @@ void P2PPeerConnectionChannel::OnSignalingChange(
   switch (new_state) {
     case PeerConnectionInterface::SignalingState::kStable:
       if (pending_remote_sdp_) {
-        RTC_LOG(LS_INFO) << "Retrying SetRemoteDescription from kStable state";
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] retrying_queued_sdp peerid=" << remote_id_;
         scoped_refptr<FunctionalSetRemoteDescriptionObserver> observer =
             FunctionalSetRemoteDescriptionObserver::Create(std::bind(
                 &P2PPeerConnectionChannel::OnSetRemoteDescriptionComplete, this,
                 std::placeholders::_1));
         std::string sdp_string;
         if (!pending_remote_sdp_->ToString(&sdp_string)) {
-          RTC_LOG(LS_ERROR) << "Error parsing local description.";
+          RTC_LOG(LS_ERROR) << "[CONN-DIAG] Error parsing local description. peerid=" << remote_id_
+                            << " msg_type=queued_offer";
           RTC_DCHECK(false);
         }
         std::vector<AudioCodec> audio_codecs;
@@ -692,7 +713,10 @@ void P2PPeerConnectionChannel::OnDataChannel(
   data_channel_->RegisterObserver(this);
 }
 void P2PPeerConnectionChannel::OnNegotiationNeeded() {
-  RTC_LOG(LS_INFO) << "On negotiation needed.";
+  rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_neg_ = GetPeerConnectionRef();
+  int sig_state = temp_pc_neg_ ? static_cast<int>(temp_pc_neg_->signaling_state()) : -1;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] negotiation_needed peerid=" << remote_id_
+                   << " signaling_state=" << sig_state;
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   if (temp_pc_ && temp_pc_->signaling_state() == PeerConnectionInterface::SignalingState::kStable) {
     CreateOffer();
@@ -701,13 +725,18 @@ void P2PPeerConnectionChannel::OnNegotiationNeeded() {
   }
 }
 void P2PPeerConnectionChannel::OnRenegotiationNeeded() {
-  RTC_LOG(LS_ERROR) << "OnRenegotiationNeeded";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] renegotiation_needed peerid=" << remote_id_;
   CreateOffer();
 }
 
 void P2PPeerConnectionChannel::OnIceConnectionChange(
     PeerConnectionInterface::IceConnectionState new_state) {
-  RTC_LOG(LS_INFO) << "Ice connection state changed: " << new_state;
+  static const char* kIceConnStateNames[] = {
+    "New","Checking","Connected","Completed","Failed","Disconnected","Closed","Max"
+  };
+  const char* ice_conn_name = (new_state >= 0 && new_state <= 7) ? kIceConnStateNames[new_state] : "unknown";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] IceConnectionState peerid=" << remote_id_
+                   << " state=" << ice_conn_name << " (" << new_state << ")";
   switch (new_state) {
     case webrtc::PeerConnectionInterface::kIceConnectionConnected:
     case webrtc::PeerConnectionInterface::kIceConnectionCompleted:
@@ -721,6 +750,7 @@ void P2PPeerConnectionChannel::OnIceConnectionChange(
       DrainPendingStreams();
       break;
     case webrtc::PeerConnectionInterface::kIceConnectionDisconnected:
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] disconnected peerid=" << remote_id_;
       // {
       //   std::lock_guard<std::mutex> lock(last_disconnect_mutex_);
       //   last_disconnect_ = std::chrono::system_clock::now();
@@ -751,6 +781,8 @@ void P2PPeerConnectionChannel::OnIceConnectionChange(
       CleanLastPeerConnection();
       break;
     case webrtc::PeerConnectionInterface::kIceConnectionFailed:
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] failed peerid=" << remote_id_
+                        << " remote_streams_count=" << remote_streams_.size();
       for (std::unordered_map<std::string,
                               std::shared_ptr<RemoteStream>>::iterator it =
                remote_streams_.begin();
@@ -768,18 +800,23 @@ void P2PPeerConnectionChannel::OnIceConnectionChange(
 }
 void P2PPeerConnectionChannel::OnIceGatheringChange(
     PeerConnectionInterface::IceGatheringState new_state) {
-  RTC_LOG(LS_INFO) << "Ice gathering state changed: " << new_state;
+  static const char* kGatherStateNames[] = {"kIceGatheringNew","kIceGatheringGathering","kIceGatheringComplete"};
+  const char* gs_name = (new_state >= 0 && new_state <= 2) ? kGatherStateNames[new_state] : "unknown";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] gathering_state peerid=" << remote_id_
+                   << " state=" << gs_name << " (" << new_state << ")";
 }
 void P2PPeerConnectionChannel::OnIceCandidate(
     const webrtc::IceCandidateInterface* candidate) {
-  RTC_LOG(LS_INFO) << "On ice candidate";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] local_candidate peerid=" << remote_id_
+                   << " sdp_mid=" << candidate->sdp_mid()
+                   << " type=" << candidate->candidate().type();
   Json::Value signal;
   signal[kSessionDescriptionTypeKey] = "candidates";
   signal[kIceCandidateSdpMLineIndexKey] = candidate->sdp_mline_index();
   signal[kIceCandidateSdpMidKey] = candidate->sdp_mid();
   string sdp;
   if (!candidate->ToString(&sdp)) {
-    RTC_LOG(LS_ERROR) << "Failed to serialize candidate";
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] Failed to serialize candidate. peerid=" << remote_id_;
     return;
   }
   signal[kIceCandidateSdpNameKey] = sdp;
@@ -799,10 +836,9 @@ void P2PPeerConnectionChannel::OnIceSelectedCandidatePairChanged(
     const cricket::CandidatePairChangeEvent& event) {
   const cricket::Candidate& local = event.selected_candidate_pair.local;
   const cricket::Candidate& remote = event.selected_candidate_pair.remote;
-  RTC_LOG(LS_ERROR) << "[ICE] selected_pair_changed"
-                    << " peerid=" << remote_id_
-                    << " local_type=" << local.type()
-                    << " remote_type=" << remote.type()
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] selected_pair_changed peerid=" << remote_id_
+                    << " local=" << local.type() << "://" << local.address().ToString()
+                    << " remote=" << remote.type() << "://" << remote.address().ToString()
                     << " local_protocol=" << local.protocol()
                     << " remote_relay_protocol=" << remote.relay_protocol()
                     << " is_relay="
@@ -813,7 +849,8 @@ void P2PPeerConnectionChannel::OnIceSelectedCandidatePairChanged(
 }
 void P2PPeerConnectionChannel::OnCreateSessionDescriptionSuccess(
     webrtc::SessionDescriptionInterface* desc) {
-  RTC_LOG(LS_INFO) << "Create sdp success.";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] sdp_created peerid=" << remote_id_
+                   << " type=" << desc->type();
   {
     std::lock_guard<std::mutex> lock(ended_mutex_);
     if (ended_) { return; }
@@ -830,11 +867,12 @@ void P2PPeerConnectionChannel::OnCreateSessionDescriptionSuccess(
 }
 void P2PPeerConnectionChannel::OnCreateSessionDescriptionFailure(
     const std::string& error) {
-  RTC_LOG(LS_ERROR) << "Create sdp failed. " << error;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Create sdp failed. peerid=" << remote_id_
+                   << " err=" << error;
   Stop(nullptr, nullptr);
 }
 void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionSuccess() {
-  RTC_LOG(LS_INFO) << "Set local sdp success.";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] set_local_sdp_success peerid=" << remote_id_;
   {
     std::lock_guard<std::mutex> lock(is_creating_offer_mutex_);
     is_creating_offer_ = false;
@@ -861,7 +899,8 @@ void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionSuccess() {
 }
 void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionFailure(
     const std::string& error) {
-  RTC_LOG(LS_ERROR) << "Set local sdp failed. " << error;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Set local sdp failed. peerid=" << remote_id_
+                   << " err=" << error;
   Stop(nullptr, nullptr);
 }
 void P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionSuccess() {
@@ -869,11 +908,14 @@ void P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionSuccess() {
     std::lock_guard<std::mutex> lock(ended_mutex_);
     if (ended_) { return; }
   }
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] set_remote_sdp_success peerid=" << remote_id_
+                   << " session_state=" << session_state_;
   PeerConnectionChannel::OnSetRemoteSessionDescriptionSuccess();
 }
 void P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionFailure(
     const std::string& error) {
-  RTC_LOG(LS_ERROR) << "Set remote sdp failed. " << error;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Set remote sdp failed. peerid=" << remote_id_
+                   << " err=" << error;
   std::cout << "Set remote_sdp FAILED" << std::endl << std::endl;
   Stop(nullptr, nullptr);
 }
@@ -951,9 +993,9 @@ void P2PPeerConnectionChannel::Unpublish(
       //   on_failure(std::move(e));
       // }
       // return;
-      RTC_LOG(LS_ERROR) << "Did not find published stream.";
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] Did not find published stream. peerid=" << remote_id_;
     } else {
-      RTC_LOG(LS_ERROR) << "Found published stream.";
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] Found published stream. peerid=" << remote_id_;
       published_streams_.erase(it);
     }
   }
@@ -969,7 +1011,8 @@ void P2PPeerConnectionChannel::Unpublish(
 void P2PPeerConnectionChannel::Stop(
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
-  RTC_LOG(LS_INFO) << "Stop session.";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Stop called peerid=" << remote_id_
+                   << " session_state=" << session_state_;
   switch (session_state_) {
     case kSessionStateConnecting:
     case kSessionStateConnected:
@@ -1109,12 +1152,11 @@ bool P2PPeerConnectionChannel::IsStale() {
                ((ice_state == webrtc::PeerConnectionInterface::kIceConnectionNew)
                 || ((ice_state == webrtc::PeerConnectionInterface::kIceConnectionFailed) &&
                    (signaling_state == webrtc::PeerConnectionInterface::kHaveLocalOffer)));
-    std::cout << "(" << age <<  " > " << kStaleThresholdSecs << ") && (("
-              << ice_state << " == " << webrtc::PeerConnectionInterface::kIceConnectionNew << ") || (("
-              << ice_state << " == " << webrtc::PeerConnectionInterface::kIceConnectionFailed << ") && ("
-              << signaling_state << " == " << webrtc::PeerConnectionInterface::kHaveLocalOffer << "))) = "
-              << is_stale
-              << std::endl;
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] IsStale peerid=" << remote_id_
+                      << " age_secs=" << age
+                      << " ice_state=" << ice_state
+                      << " signaling_state=" << signaling_state
+                      << " is_stale=" << is_stale;
   } else {
     is_stale = true;
   }
@@ -1158,7 +1200,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       bool is_to_be_unpublished = false;
       for (auto& un_stream : unpublish_snapshot) {
         if (stream == un_stream) { // comparison of pointers;
-          RTC_LOG(LS_ERROR) << "Trying to Publish and Unpublish stream.";
+          RTC_LOG(LS_ERROR) << "[CONN-DIAG] Trying to Publish and Unpublish stream. peerid=" << remote_id_;
           is_to_be_unpublished = true;
           break;
         }
@@ -1256,7 +1298,8 @@ void P2PPeerConnectionChannel::SendStop(
 }
 // Only function that holds locks while calling WebRTC methods. Any deadlock is here.
 void P2PPeerConnectionChannel::ClosePeerConnection() {
-  RTC_LOG(LS_INFO) << "Close peer connection.";
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] ClosePeerConnection peerid=" << remote_id_
+                   << " already_ended=" << ended_;
   // Reference to peer connection  that outlives the scope of the locks.
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_;
   rtc::scoped_refptr<webrtc::DataChannelInterface> temp_dc_;
@@ -1298,9 +1341,12 @@ void P2PPeerConnectionChannel::CheckWaitedList() {
 }
 
 void P2PPeerConnectionChannel::OnDataChannelStateChange() {
-  if (data_channel_ && data_channel_->state() ==
-      webrtc::DataChannelInterface::DataState::kOpen) {
-    DrainPendingMessages();
+  if (data_channel_) {
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] datachannel_state peerid=" << remote_id_
+                     << " state=" << data_channel_->state();
+    if (data_channel_->state() == webrtc::DataChannelInterface::DataState::kOpen) {
+      DrainPendingMessages();
+    }
   }
 }
 void P2PPeerConnectionChannel::OnDataChannelMessage(
@@ -1385,7 +1431,8 @@ void P2PPeerConnectionChannel::DrainPendingRemoteCandidates() {
   // and pending remote candidates have already been cleared.
   if (temp_pc_ && temp_pc_->remote_description()) {
     rtc::CritScope cs(&pending_remote_candidates_crit_);
-    RTC_LOG(LS_INFO) << "Draining pending ICE Candidates, received " << pending_remote_candidates_.size();
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] drain_pending_candidates peerid=" << remote_id_
+                      << " count=" << pending_remote_candidates_.size();
     for (const auto& ice_candidate : pending_remote_candidates_) {
       if (!temp_pc_->AddIceCandidate(ice_candidate.get())) {
         RTC_LOG(LS_WARNING) << "Failed to add remote candidate.";

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -490,7 +490,7 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
     std::unique_ptr<webrtc::SessionDescriptionInterface> desc(
         webrtc::CreateSessionDescription(type, sdp, nullptr));
     if (!desc) {
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG] Failed to create session description. peerid=" << remote_id_
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Failed to create session description. peerid=" << remote_id_
                         << " msg_type=" << type;
       return;
     }
@@ -505,7 +505,7 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
               std::placeholders::_1));
       std::string sdp_string;
       if (!desc->ToString(&sdp_string)) {
-        RTC_LOG(LS_ERROR) << "[CONN-DIAG] Error parsing local description. peerid=" << remote_id_
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Error parsing local description. peerid=" << remote_id_
                           << " msg_type=" << type;
         RTC_DCHECK(false);
       }
@@ -620,7 +620,7 @@ void P2PPeerConnectionChannel::OnSignalingChange(
                 std::placeholders::_1));
         std::string sdp_string;
         if (!pending_remote_sdp_->ToString(&sdp_string)) {
-          RTC_LOG(LS_ERROR) << "[CONN-DIAG] Error parsing local description. peerid=" << remote_id_
+          RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Error parsing local description. peerid=" << remote_id_
                             << " msg_type=queued_offer";
           RTC_DCHECK(false);
         }
@@ -781,7 +781,7 @@ void P2PPeerConnectionChannel::OnIceConnectionChange(
       CleanLastPeerConnection();
       break;
     case webrtc::PeerConnectionInterface::kIceConnectionFailed:
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] failed peerid=" << remote_id_
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE][WARN] failed peerid=" << remote_id_
                         << " remote_streams_count=" << remote_streams_.size();
       for (std::unordered_map<std::string,
                               std::shared_ptr<RemoteStream>>::iterator it =
@@ -816,7 +816,7 @@ void P2PPeerConnectionChannel::OnIceCandidate(
   signal[kIceCandidateSdpMidKey] = candidate->sdp_mid();
   string sdp;
   if (!candidate->ToString(&sdp)) {
-    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] Failed to serialize candidate. peerid=" << remote_id_;
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE][ERROR] Failed to serialize candidate. peerid=" << remote_id_;
     return;
   }
   signal[kIceCandidateSdpNameKey] = sdp;
@@ -867,7 +867,7 @@ void P2PPeerConnectionChannel::OnCreateSessionDescriptionSuccess(
 }
 void P2PPeerConnectionChannel::OnCreateSessionDescriptionFailure(
     const std::string& error) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Create sdp failed. peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Create sdp failed. peerid=" << remote_id_
                    << " err=" << error;
   Stop(nullptr, nullptr);
 }
@@ -899,7 +899,7 @@ void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionSuccess() {
 }
 void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionFailure(
     const std::string& error) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Set local sdp failed. peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Set local sdp failed. peerid=" << remote_id_
                    << " err=" << error;
   Stop(nullptr, nullptr);
 }
@@ -914,7 +914,7 @@ void P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionSuccess() {
 }
 void P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionFailure(
     const std::string& error) {
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] Set remote sdp failed. peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] Set remote sdp failed. peerid=" << remote_id_
                    << " err=" << error;
   std::cout << "Set remote_sdp FAILED" << std::endl << std::endl;
   Stop(nullptr, nullptr);

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1,6 +1,18 @@
 // Copyright (C) <2018> Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
+//
+// NOTE: Log severity — all [CONN-DIAG] logs in this file use RTC_LOG(LS_ERROR)
+// regardless of their actual severity. This is because the appliance binary sets
+// OWT log severity to kError (see main.cc: owt::base::Logging::Severity(kError)),
+// which silently drops LS_INFO and LS_WARNING. Informational lifecycle events
+// are logged at LS_ERROR purely to make them visible; they are not actual errors.
+// Lines marked "// LS_INFO (elevated to LS_ERROR — see file header note)" below
+// should be reverted to their correct severity once the binary-level fix is done.
+//
+// TODO: Fix at binary level — configure OWT to emit LS_INFO or lower so log
+// levels here can be set correctly (LS_INFO for lifecycle events, LS_WARNING
+// for non-critical issues, LS_ERROR only for genuine failures).
 #include <thread>
 #include <vector>
 #include <iostream>
@@ -167,6 +179,7 @@ void P2PPeerConnectionChannel::Publish(
     std::shared_ptr<LocalStream> stream,
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=Publishing a local stream. peerid=" << remote_id_
                    << " session_state=" << session_state_;
   // Add reference to peer connection until end of function.
@@ -251,6 +264,7 @@ void P2PPeerConnectionChannel::Publish(
     std::lock_guard<std::mutex> lock(published_streams_mutex_);
     publishing_streams_.insert(stream_label);
   }
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=stream_queued_for_publish peerid=" << remote_id_
                    << " session_state=" << session_state_
                    << " pending_streams=" << pending_publish_streams_.size();
@@ -339,6 +353,7 @@ void P2PPeerConnectionChannel::CreateOffer() {
     }
   }
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=create_offer peerid=" << remote_id_;
   negotiation_needed_ = false;
   scoped_refptr<FunctionalCreateSessionDescriptionObserver> observer =
@@ -355,6 +370,7 @@ void P2PPeerConnectionChannel::CreateOffer() {
   }
 }
 void P2PPeerConnectionChannel::CreateAnswer() {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=create_answer peerid=" << remote_id_;
   // Get reference so peer_connection_ is not deleted before calling CreateAnswer
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
@@ -405,6 +421,7 @@ void P2PPeerConnectionChannel::OnIncomingSignalingMessage(
     RTC_LOG(LS_WARNING) << "Cannot get type from incoming message.";
     return;
   }
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=incoming_message peerid=" << remote_id_
                     << " msg_type=" << message_type;
   if (message_type == kChatUserAgent) {
@@ -444,6 +461,7 @@ void P2PPeerConnectionChannel::OnIncomingSignalingMessage(
   }
 }
 void P2PPeerConnectionChannel::OnMessageUserAgent(Json::Value& ua) {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=ua_received peerid=" << remote_id_
                    << " session_state=" << session_state_;
   HandleRemoteCapability(ua);
@@ -458,6 +476,7 @@ void P2PPeerConnectionChannel::OnMessageUserAgent(Json::Value& ua) {
   }
 }
 void P2PPeerConnectionChannel::OnMessageStop() {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=Remote user stopped. peerid=" << remote_id_
                    << " session_state=" << session_state_;
   ClosePeerConnection();
@@ -467,6 +486,7 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
   string type;
   string desc;
   rtc::GetStringFromJsonObject(message, kSessionDescriptionTypeKey, &type);
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=signal_received peerid=" << remote_id_
                    << " msg_type=" << type
                    << " session_state=" << session_state_;
@@ -495,6 +515,7 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
       return;
     }
     if (type == "offer" && temp_pc_ && temp_pc_->signaling_state() != webrtc::PeerConnectionInterface::kStable) {
+      // LS_INFO (elevated to LS_ERROR — see file header note)
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=sdp_offer_queued peerid=" << remote_id_
                         << " signaling_state=" << static_cast<int>(temp_pc_->signaling_state());
       pending_remote_sdp_ = std::move(desc);
@@ -523,12 +544,14 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
           webrtc::CreateSessionDescription(desc->type(), sdp_string, nullptr));
       // Synchronous call. After done, will invoke OnSetRemoteDescription. If
       // remote sent an offer, we create answer for it.
+      // LS_INFO (elevated to LS_ERROR — see file header note)
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=set_remote_description peerid=" << remote_id_
                        << " msg_type=" << type;
       temp_pc_->SetRemoteDescription(std::move(new_desc), observer);
       pending_remote_sdp_.reset();
     }
   } else if (type == "candidates") {
+    // LS_INFO (elevated to LS_ERROR — see file header note)
     RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=remote_candidate_received peerid=" << remote_id_;
     string sdp_mid;
     string candidate;
@@ -554,6 +577,7 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
 }
 void P2PPeerConnectionChannel::OnMessageTracksAdded(
     Json::Value& stream_tracks) {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=tracks_added_ack peerid=" << remote_id_
                    << " track_count=" << stream_tracks.size();
   // Find the streams with track information, and add them to published stream
@@ -600,6 +624,7 @@ void P2PPeerConnectionChannel::OnSignalingChange(
     "kStable","kHaveLocalOffer","kHaveLocalPrAnswer","kHaveRemoteOffer","kHaveRemotePrAnswer","kClosed"
   };
   const char* state_name = (new_state >= 0 && new_state <= 5) ? kSigStateNames[new_state] : "unknown";
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=signaling_state peerid=" << remote_id_
                    << " state=" << state_name << " (" << new_state << ")";
 
@@ -613,6 +638,7 @@ void P2PPeerConnectionChannel::OnSignalingChange(
   switch (new_state) {
     case PeerConnectionInterface::SignalingState::kStable:
       if (pending_remote_sdp_) {
+        // LS_INFO (elevated to LS_ERROR — see file header note)
         RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=retrying_queued_sdp peerid=" << remote_id_;
         scoped_refptr<FunctionalSetRemoteDescriptionObserver> observer =
             FunctionalSetRemoteDescriptionObserver::Create(std::bind(
@@ -715,6 +741,7 @@ void P2PPeerConnectionChannel::OnDataChannel(
 void P2PPeerConnectionChannel::OnNegotiationNeeded() {
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_neg_ = GetPeerConnectionRef();
   int sig_state = temp_pc_neg_ ? static_cast<int>(temp_pc_neg_->signaling_state()) : -1;
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=negotiation_needed peerid=" << remote_id_
                    << " signaling_state=" << sig_state;
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
@@ -725,6 +752,7 @@ void P2PPeerConnectionChannel::OnNegotiationNeeded() {
   }
 }
 void P2PPeerConnectionChannel::OnRenegotiationNeeded() {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=renegotiation_needed peerid=" << remote_id_;
   CreateOffer();
 }
@@ -735,6 +763,7 @@ void P2PPeerConnectionChannel::OnIceConnectionChange(
     "New","Checking","Connected","Completed","Failed","Disconnected","Closed","Max"
   };
   const char* ice_conn_name = (new_state >= 0 && new_state <= 7) ? kIceConnStateNames[new_state] : "unknown";
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=IceConnectionState peerid=" << remote_id_
                    << " state=" << ice_conn_name << " (" << new_state << ")";
   switch (new_state) {
@@ -750,6 +779,7 @@ void P2PPeerConnectionChannel::OnIceConnectionChange(
       DrainPendingStreams();
       break;
     case webrtc::PeerConnectionInterface::kIceConnectionDisconnected:
+      // LS_INFO (elevated to LS_ERROR — see file header note)
       RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=disconnected peerid=" << remote_id_;
       // {
       //   std::lock_guard<std::mutex> lock(last_disconnect_mutex_);
@@ -802,11 +832,13 @@ void P2PPeerConnectionChannel::OnIceGatheringChange(
     PeerConnectionInterface::IceGatheringState new_state) {
   static const char* kGatherStateNames[] = {"kIceGatheringNew","kIceGatheringGathering","kIceGatheringComplete"};
   const char* gs_name = (new_state >= 0 && new_state <= 2) ? kGatherStateNames[new_state] : "unknown";
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=gathering_state peerid=" << remote_id_
                    << " state=" << gs_name << " (" << new_state << ")";
 }
 void P2PPeerConnectionChannel::OnIceCandidate(
     const webrtc::IceCandidateInterface* candidate) {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=local_candidate peerid=" << remote_id_
                    << " sdp_mid=" << candidate->sdp_mid()
                    << " type=" << candidate->candidate().type();
@@ -836,6 +868,7 @@ void P2PPeerConnectionChannel::OnIceSelectedCandidatePairChanged(
     const cricket::CandidatePairChangeEvent& event) {
   const cricket::Candidate& local = event.selected_candidate_pair.local;
   const cricket::Candidate& remote = event.selected_candidate_pair.remote;
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=selected_pair_changed peerid=" << remote_id_
                     << " local=" << local.type() << "://" << local.address().ToString()
                     << " remote=" << remote.type() << "://" << remote.address().ToString()
@@ -849,6 +882,7 @@ void P2PPeerConnectionChannel::OnIceSelectedCandidatePairChanged(
 }
 void P2PPeerConnectionChannel::OnCreateSessionDescriptionSuccess(
     webrtc::SessionDescriptionInterface* desc) {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=sdp_created peerid=" << remote_id_
                    << " type=" << desc->type();
   {
@@ -872,6 +906,7 @@ void P2PPeerConnectionChannel::OnCreateSessionDescriptionFailure(
   Stop(nullptr, nullptr);
 }
 void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionSuccess() {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=set_local_sdp_success peerid=" << remote_id_;
   {
     std::lock_guard<std::mutex> lock(is_creating_offer_mutex_);
@@ -908,6 +943,7 @@ void P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionSuccess() {
     std::lock_guard<std::mutex> lock(ended_mutex_);
     if (ended_) { return; }
   }
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=set_remote_sdp_success peerid=" << remote_id_
                    << " session_state=" << session_state_;
   PeerConnectionChannel::OnSetRemoteSessionDescriptionSuccess();
@@ -993,8 +1029,10 @@ void P2PPeerConnectionChannel::Unpublish(
       //   on_failure(std::move(e));
       // }
       // return;
+      // LS_INFO (elevated to LS_ERROR — see file header note)
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=Did not find published stream. peerid=" << remote_id_;
     } else {
+      // LS_INFO (elevated to LS_ERROR — see file header note)
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=Found published stream. peerid=" << remote_id_;
       published_streams_.erase(it);
     }
@@ -1011,6 +1049,7 @@ void P2PPeerConnectionChannel::Unpublish(
 void P2PPeerConnectionChannel::Stop(
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=stop_called peerid=" << remote_id_
                    << " session_state=" << session_state_;
   switch (session_state_) {
@@ -1152,6 +1191,7 @@ bool P2PPeerConnectionChannel::IsStale() {
                ((ice_state == webrtc::PeerConnectionInterface::kIceConnectionNew)
                 || ((ice_state == webrtc::PeerConnectionInterface::kIceConnectionFailed) &&
                    (signaling_state == webrtc::PeerConnectionInterface::kHaveLocalOffer)));
+    // LS_INFO (elevated to LS_ERROR — see file header note)
     RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=is_stale peerid=" << remote_id_
                       << " age_secs=" << age
                       << " ice_state=" << ice_state
@@ -1200,6 +1240,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       bool is_to_be_unpublished = false;
       for (auto& un_stream : unpublish_snapshot) {
         if (stream == un_stream) { // comparison of pointers;
+          // LS_INFO (elevated to LS_ERROR — see file header note)
           RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=Trying to Publish and Unpublish stream. peerid=" << remote_id_;
           is_to_be_unpublished = true;
           break;
@@ -1298,6 +1339,7 @@ void P2PPeerConnectionChannel::SendStop(
 }
 // Only function that holds locks while calling WebRTC methods. Any deadlock is here.
 void P2PPeerConnectionChannel::ClosePeerConnection() {
+  // LS_INFO (elevated to LS_ERROR — see file header note)
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=close_peer_connection peerid=" << remote_id_
                    << " already_ended=" << ended_;
   // Reference to peer connection  that outlives the scope of the locks.
@@ -1342,6 +1384,7 @@ void P2PPeerConnectionChannel::CheckWaitedList() {
 
 void P2PPeerConnectionChannel::OnDataChannelStateChange() {
   if (data_channel_) {
+    // LS_INFO (elevated to LS_ERROR — see file header note)
     RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=datachannel_state peerid=" << remote_id_
                      << " state=" << data_channel_->state();
     if (data_channel_->state() == webrtc::DataChannelInterface::DataState::kOpen) {
@@ -1431,6 +1474,7 @@ void P2PPeerConnectionChannel::DrainPendingRemoteCandidates() {
   // and pending remote candidates have already been cleared.
   if (temp_pc_ && temp_pc_->remote_description()) {
     rtc::CritScope cs(&pending_remote_candidates_crit_);
+    // LS_INFO (elevated to LS_ERROR — see file header note)
     RTC_LOG(LS_ERROR) << "[CONN-DIAG][ICE] event=drain_pending_candidates peerid=" << remote_id_
                       << " count=" << pending_remote_candidates_.size();
     for (const auto& ice_candidate : pending_remote_candidates_) {


### PR DESCRIPTION
## WebRTC Connection Diagnostic Logging — owt-client-native

Pure logging change. Zero functional or operational modifications. All logs use `RTC_LOG(LS_ERROR)` — required because the appliance sets OWT log severity to `kError`, making `LS_INFO`/`LS_WARNING` invisible.

All logs follow the format:

```
[CONN-DIAG][<category>][<severity>] event=<name> peerid=<uuid>:<user@email> key=val ...
```

`[ICE]` — ICE-layer event. `[ERROR]` / `[WARN]` — severity tag. Events without severity tag are informational.

---

### Logs enabled

**Stream publish path** — previously completely invisible (were at `LS_INFO`):

```
[CONN-DIAG] event=Publishing a local stream. peerid=ad6be775:piyush.mittal@ambient.ai session_state=1
[CONN-DIAG] event=stream_queued_for_publish peerid=ad6be775:piyush.mittal@ambient.ai session_state=1 pending_streams=1
[CONN-DIAG] event=create_offer peerid=ad6be775:piyush.mittal@ambient.ai
[CONN-DIAG] event=create_answer peerid=ad6be775:piyush.mittal@ambient.ai
[CONN-DIAG] event=sdp_created peerid=ad6be775:piyush.mittal@ambient.ai type=offer
[CONN-DIAG] event=set_local_sdp_success peerid=ad6be775:piyush.mittal@ambient.ai
```

**Signaling exchange:**

```
[CONN-DIAG] event=incoming_message peerid=ad6be775:piyush.mittal@ambient.ai msg_type=chat-signal
[CONN-DIAG] event=ua_received peerid=ad6be775:piyush.mittal@ambient.ai session_state=5
[CONN-DIAG] event=signal_received peerid=ad6be775:piyush.mittal@ambient.ai msg_type=answer session_state=5
[CONN-DIAG] event=set_remote_description peerid=ad6be775:piyush.mittal@ambient.ai msg_type=answer
[CONN-DIAG] event=set_remote_sdp_success peerid=ad6be775:piyush.mittal@ambient.ai session_state=5
[CONN-DIAG] event=signaling_state peerid=ad6be775:piyush.mittal@ambient.ai state=kStable (0)
[CONN-DIAG] event=tracks_added_ack peerid=ad6be775:piyush.mittal@ambient.ai track_count=1
[CONN-DIAG] event=negotiation_needed peerid=ad6be775:piyush.mittal@ambient.ai signaling_state=0
[CONN-DIAG] event=renegotiation_needed peerid=ad6be775:piyush.mittal@ambient.ai
[CONN-DIAG] event=sdp_offer_queued peerid=ad6be775:piyush.mittal@ambient.ai signaling_state=1
[CONN-DIAG] event=retrying_queued_sdp peerid=ad6be775:piyush.mittal@ambient.ai
```

> `sdp_offer_queued` + `retrying_queued_sdp` diagnose reconnect latency when SDP arrives while signaling is not stable.

**ICE layer** — `IceConnectionState` was previously at `LS_INFO`, completely invisible:

```
[CONN-DIAG][ICE] event=IceConnectionState peerid=ad6be775:piyush.mittal@ambient.ai state=Checking (1)
[CONN-DIAG][ICE] event=IceConnectionState peerid=ad6be775:piyush.mittal@ambient.ai state=Connected (2)
[CONN-DIAG][ICE] event=IceConnectionState peerid=ad6be775:piyush.mittal@ambient.ai state=Disconnected (5)
[CONN-DIAG][ICE] event=IceConnectionState peerid=ad6be775:piyush.mittal@ambient.ai state=Failed (4)
[CONN-DIAG][ICE][WARN] event=ice_failed peerid=ad6be775:piyush.mittal@ambient.ai remote_streams_count=0
[CONN-DIAG][ICE] event=gathering_state peerid=ad6be775:piyush.mittal@ambient.ai state=kIceGatheringGathering (1)
[CONN-DIAG][ICE] event=local_candidate peerid=ad6be775:piyush.mittal@ambient.ai sdp_mid=1 type=relay
[CONN-DIAG][ICE] event=remote_candidate_received peerid=ad6be775:piyush.mittal@ambient.ai
[CONN-DIAG][ICE] event=drain_pending_candidates peerid=ad6be775:piyush.mittal@ambient.ai count=0
[CONN-DIAG][ICE] event=selected_pair_changed peerid=ad6be775:piyush.mittal@ambient.ai local=relay://54.244.51.32:35320 remote=prflx://:20525 local_protocol=udp is_relay=true reason=candidate pair state changed
```

> `selected_pair_changed` now includes IP:port of both endpoints — shows relay vs direct path and any mid-call path changes.

**Connection teardown:**

```
[CONN-DIAG] event=Remote user stopped. peerid=ad6be775:piyush.mittal@ambient.ai session_state=5
[CONN-DIAG] event=stop_called peerid=ad6be775:piyush.mittal@ambient.ai session_state=5
[CONN-DIAG] event=close_peer_connection peerid=ad6be775:piyush.mittal@ambient.ai already_ended=0
[CONN-DIAG] event=datachannel_state peerid=ad6be775:piyush.mittal@ambient.ai state=1
[CONN-DIAG] event=is_stale peerid=ad6be775:piyush.mittal@ambient.ai age_secs=41 ice_state=4 signaling_state=0 is_stale=0
```

**Failure paths** — previously bare strings with no `peerid`, impossible to correlate:

```
[CONN-DIAG][ERROR] event=Failed to create session description. peerid=ad6be775:piyush.mittal@ambient.ai msg_type=offer
[CONN-DIAG][ERROR] event=Create sdp failed. peerid=ad6be775:piyush.mittal@ambient.ai err=…
[CONN-DIAG][ERROR] event=Set local sdp failed. peerid=ad6be775:piyush.mittal@ambient.ai err=…
[CONN-DIAG][ERROR] event=Set remote sdp failed. peerid=ad6be775:piyush.mittal@ambient.ai err=…
[CONN-DIAG][ICE][ERROR] event=Failed to serialize candidate. peerid=ad6be775:piyush.mittal@ambient.ai
```

**Unpublish / conflict paths:**

```
[CONN-DIAG] event=Did not find published stream. peerid=ad6be775:piyush.mittal@ambient.ai
[CONN-DIAG] event=Trying to Publish and Unpublish stream. peerid=ad6be775:piyush.mittal@ambient.ai
```

**Stale detection** — previously written to `stdout` via `std::cout`, now properly logged:

```
[CONN-DIAG] event=is_stale peerid=ad6be775:piyush.mittal@ambient.ai age_secs=41 ice_state=4 signaling_state=0 is_stale=0
```
### LOG Volume
*I instrumented couple of busiest node on ebay and found out these in 24h these logs contributed to ~2.78% of our total log volume on a node*

### Dashbords
Note: We already deployed these logs to 50 nodes and found out couple of issues and this will help use to fix and monitor couple of issues.
Peer Level :- [Link](https://edgelogs.prod.ambient.ai/_dashboards/app/dashboards#/view/cd-peer-dashboard?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2026-06-29T12:34:03.452Z',to:'2026-06-29T14:39:28.841Z'))&_a=(description:'Per-viewer%20WebRTC%20connection%20diagnostics.%20Add%20a%20cd.peerid%20filter%20to%20trace%20one%20viewer%20full%20lifecycle.%20Edit%20node_id%20filter%20to%20scope%20to%20a%20specific%20appliance.',filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'4ba14550-04b4-11f0-813d-3fd0da2103db',key:node_id,negate:!f,params:(query:ebay-sanjose-node6),type:phrase),query:(match_phrase:(node_id:ebay-sanjose-node6)))),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!f,title:'WebRTC%20CONN-DIAG%20-%20Viewer%20(Peer%20Level)',viewMode:view))
Fleet Level:- [Link](https://edgelogs.prod.ambient.ai/_dashboards/app/dashboards#/view/cd-node-dashboard?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2026-06-30T10:24:38.815Z',to:'2026-07-01T08:54:11.531Z'))&_a=(description:'Node-level%20WebRTC%20health%20%E2%80%94%20viewer%20load,%20ICE%20failures,%20server%20kills,%20pool%20starvation,%20OS%20CPU%2Fbuffer%20health.%20Correlate%20OS%20bottleneck%20charts%20with%20ICE%20failure%20spikes%20to%20diagnose%20starvation.',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!f,title:'WebRTC%20CONN-DIAG%20-%20Node%20(Fleet%20Health)',viewMode:view))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only in one file with no control-flow changes; main operational impact is higher ERROR-level log volume (~2.8% on sampled nodes).
> 
> **Overview**
> Adds structured **`[CONN-DIAG]`** diagnostic logging across **`P2PPeerConnectionChannel`** so P2P WebRTC publish, signaling, ICE, teardown, and failure paths are visible in production logs.
> 
> Because the appliance runs OWT at **`kError`**, previously **`LS_INFO`** / **`LS_WARNING`** lifecycle lines are emitted at **`LS_ERROR`** (documented in a file-header note and **`TODO`** to fix severity at **`main.cc`**). Messages use a consistent **`event=… peerid=…`** shape, with **`[ICE]`**, **`[ERROR]`**, and **`[WARN]`** tags where relevant; numeric ICE/signaling states are mapped to readable names.
> 
> Coverage includes publish/offer/answer/SDP success and failure, incoming signaling, queued offers (**`sdp_offer_queued`** / **`retrying_queued_sdp`**), negotiation/renegotiation, ICE connection/gathering/candidates/selected pair (now with local/remote **IP:port**), stop/close, data channel state, unpublish edge cases, and **`IsStale`** output moved from **`std::cout`** to **`RTC_LOG`**. **`OnDataChannelStateChange`** now logs every channel state while still draining pending messages only when open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92b280017c32a17942f622214ce23a2d9505eb8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->