### PR TITLE
Increase min bitrate for all connections to 32 Mbps.

### DIFF
--- a/talk/owt/sdk/base/peerconnectionchannel.cc
+++ b/talk/owt/sdk/base/peerconnectionchannel.cc
@@ -10,7 +10,7 @@
 using namespace rtc;
 namespace owt {
 namespace base {
-static constexpr int kBweOptimizationSettingsMinBitrateBps = 500000;  // 500 kbps
+static constexpr int kBweOptimizationSettingsMinBitrateBps = 32000000;  // 32 Mbps
 static constexpr double kVideoBitratePriority = 1.0;                  // Equal across all tiles
 PeerConnectionChannel::PeerConnectionChannel(
     PeerConnectionChannelConfiguration configuration)


### PR DESCRIPTION
# Summary
* 2 Mbps per connection is the minimum rate that we need for video walls. Also for connections with lower stream count, the actual bandwidth used is not high.
* On blg nairobi this has been enabled and the output bandwidth usage has increased but is not insanely high so there is no padding being applied here.

<img width="1844" height="219" alt="Screenshot 2026-06-30 at 18 55 51" src="https://github.com/user-attachments/assets/918f9c9d-098f-4229-9ce0-a28ac2c83941" />
