### PR TITLE
Make libwebrtc network_thread real-time (SCHED_RR) to prevent ICE keepalive starvation

### DIFF
--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -20,6 +20,11 @@
 #include "webrtc/rtc_base/bind.h"
 #include "webrtc/rtc_base/ssl_adapter.h"
 #include "webrtc/rtc_base/thread.h"
+#include "webrtc/rtc_base/logging.h"
+#include <pthread.h>
+#include <sched.h>
+#include <cstring>
+#include <cerrno>
 #include "webrtc/system_wrappers/include/field_trial.h"
 #if defined(WEBRTC_WIN)
 #include "talk/owt/sdk/base/win/msdkvideodecoderfactory.h"
@@ -124,6 +129,31 @@ void PeerConnectionDependencyFactory::
   RTC_CHECK(worker_thread->Start() && signaling_thread->Start() &&
             network_thread->Start())
       << "Failed to start threads";
+
+  // [CONN-DIAG] Make media-critical libwebrtc threads real-time so they are
+  // not CPU-starved under heavy load (e.g. co-located transcoding workloads).
+  // A starved network_thread cannot drain UDP sockets in time; the kernel drops
+  // inbound STUN consent-freshness keepalives; the browser then sees no response
+  // for ~15s, declares ICE failed, and tears the stream down. SCHED_RR lets
+  // these threads preempt transcoders just long enough to answer STUN and move
+  // media. Best-effort: logs but does not abort if CAP_SYS_NICE is unavailable.
+  auto make_realtime = [](rtc::Thread* t, const char* tname) {
+    if (t == nullptr) return;
+    t->Invoke<void>(RTC_FROM_HERE, [tname]() {
+      struct sched_param sp;
+      std::memset(&sp, 0, sizeof(sp));
+      sp.sched_priority = 20;  // modest RT priority, well below kernel threads
+      if (pthread_setschedparam(pthread_self(), SCHED_RR, &sp) != 0) {
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] could NOT set SCHED_RR on " << tname
+                          << " (need CAP_SYS_NICE): " << std::strerror(errno);
+      } else {
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] " << tname << " set to SCHED_RR prio 20";
+      }
+    });
+  };
+  make_realtime(network_thread.get(), "network_thread");
+  // make_realtime(worker_thread.get(), "worker_thread");
+  // make_realtime(signaling_thread.get(), "signaling_thread");
 
   // Use webrtc::VideoEn(De)coderFactory on iOS.
   std::unique_ptr<webrtc::VideoEncoderFactory> encoder_factory;

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -21,10 +21,13 @@
 #include "webrtc/rtc_base/ssl_adapter.h"
 #include "webrtc/rtc_base/thread.h"
 #include "webrtc/rtc_base/logging.h"
+#if defined(WEBRTC_LINUX)
+// POSIX real-time scheduling for network_thread — Linux only.
 #include <pthread.h>
 #include <sched.h>
 #include <cstring>
 #include <cerrno>
+#endif
 #include "webrtc/system_wrappers/include/field_trial.h"
 #if defined(WEBRTC_WIN)
 #include "talk/owt/sdk/base/win/msdkvideodecoderfactory.h"
@@ -130,6 +133,7 @@ void PeerConnectionDependencyFactory::
             network_thread->Start())
       << "Failed to start threads";
 
+#if defined(WEBRTC_LINUX)
   // [CONN-DIAG] Give network_thread SCHED_RR so it preempts co-located
   // transcoders to answer STUN keepalives; otherwise it starves, the kernel
   // drops keepalives, and the browser declares ICE failed (~15s) and drops the
@@ -137,6 +141,8 @@ void PeerConnectionDependencyFactory::
   // Non-throwing: none of pthread_setschedparam / RTC_LOG / strerror throw, and
   // OWT is built with -fno-exceptions, so no try/catch is possible or needed —
   // a scheduling failure just logs and continues, never crashing the binary.
+  // Linux-only: pthread_setschedparam / SCHED_RR are POSIX and this binary only
+  // ships on Linux appliances.
   auto make_realtime = [](rtc::Thread* t, const char* tname) {
     if (t == nullptr) return;
     t->Invoke<void>(RTC_FROM_HERE, [tname]() {
@@ -158,6 +164,7 @@ void PeerConnectionDependencyFactory::
     });
   };
   make_realtime(network_thread.get(), "network_thread");
+#endif  // WEBRTC_LINUX
 
   // Use webrtc::VideoEn(De)coderFactory on iOS.
   std::unique_ptr<webrtc::VideoEncoderFactory> encoder_factory;

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -144,16 +144,15 @@ void PeerConnectionDependencyFactory::
       std::memset(&sp, 0, sizeof(sp));
       sp.sched_priority = 20;  // modest RT priority, well below kernel threads
       if (pthread_setschedparam(pthread_self(), SCHED_RR, &sp) != 0) {
-        RTC_LOG(LS_ERROR) << "[CONN-DIAG] could NOT set SCHED_RR on " << tname
-                          << " (need CAP_SYS_NICE): " << std::strerror(errno);
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=sched_rr_failed thread=" << tname
+                          << " prio=20 err=" << std::strerror(errno);
       } else {
-        RTC_LOG(LS_ERROR) << "[CONN-DIAG] " << tname << " set to SCHED_RR prio 20";
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=sched_rr_applied thread=" << tname
+                          << " prio=20";
       }
     });
   };
   make_realtime(network_thread.get(), "network_thread");
-  // make_realtime(worker_thread.get(), "worker_thread");
-  // make_realtime(signaling_thread.get(), "signaling_thread");
 
   // Use webrtc::VideoEn(De)coderFactory on iOS.
   std::unique_ptr<webrtc::VideoEncoderFactory> encoder_factory;

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -134,33 +134,28 @@ void PeerConnectionDependencyFactory::
   // transcoders to answer STUN keepalives; otherwise it starves, the kernel
   // drops keepalives, and the browser declares ICE failed (~15s) and drops the
   // stream. Best-effort: never crashes; logs and continues if it can't apply.
+  // Non-throwing: none of pthread_setschedparam / RTC_LOG / strerror throw, and
+  // OWT is built with -fno-exceptions, so no try/catch is possible or needed —
+  // a scheduling failure just logs and continues, never crashing the binary.
   auto make_realtime = [](rtc::Thread* t, const char* tname) {
     if (t == nullptr) return;
-    try {
-      t->Invoke<void>(RTC_FROM_HERE, [tname]() {
-        struct sched_param sp;
-        std::memset(&sp, 0, sizeof(sp));
-        sp.sched_priority = 20;  // modest RT priority, well below kernel threads
-        // pthread_setschedparam returns the error code directly and does NOT set
-        // errno — must use the return value, not errno, to report the failure.
-        int rc = pthread_setschedparam(pthread_self(), SCHED_RR, &sp);
-        if (rc != 0) {
-          RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=sched_rr_failed thread=" << tname
-                            << " prio=20 err=" << std::strerror(rc);
-        } else {
-          // LS_ERROR (not LS_INFO): OWT is set to kError severity which drops
-          // LS_INFO. This is informational, not a real error.
-          RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=sched_rr_applied thread=" << tname
-                            << " prio=20";
-        }
-      });
-    } catch (const std::exception& e) {
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=sched_rr_exception thread=" << tname
-                        << " err=" << e.what();
-    } catch (...) {
-      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=sched_rr_exception thread=" << tname
-                        << " err=unknown";
-    }
+    t->Invoke<void>(RTC_FROM_HERE, [tname]() {
+      struct sched_param sp;
+      std::memset(&sp, 0, sizeof(sp));
+      sp.sched_priority = 20;  // modest RT priority, well below kernel threads
+      // pthread_setschedparam returns the error code directly and does NOT set
+      // errno — must use the return value, not errno, to report the failure.
+      int rc = pthread_setschedparam(pthread_self(), SCHED_RR, &sp);
+      if (rc != 0) {
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=sched_rr_failed thread=" << tname
+                          << " prio=20 err=" << std::strerror(rc);
+      } else {
+        // LS_ERROR (not LS_INFO): OWT is set to kError severity which drops
+        // LS_INFO. This is informational, not a real error.
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=sched_rr_applied thread=" << tname
+                          << " prio=20";
+      }
+    });
   };
   make_realtime(network_thread.get(), "network_thread");
 

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -130,27 +130,37 @@ void PeerConnectionDependencyFactory::
             network_thread->Start())
       << "Failed to start threads";
 
-  // [CONN-DIAG] Make media-critical libwebrtc threads real-time so they are
-  // not CPU-starved under heavy load (e.g. co-located transcoding workloads).
-  // A starved network_thread cannot drain UDP sockets in time; the kernel drops
-  // inbound STUN consent-freshness keepalives; the browser then sees no response
-  // for ~15s, declares ICE failed, and tears the stream down. SCHED_RR lets
-  // these threads preempt transcoders just long enough to answer STUN and move
-  // media. Best-effort: logs but does not abort if CAP_SYS_NICE is unavailable.
+  // [CONN-DIAG] Give network_thread SCHED_RR so it preempts co-located
+  // transcoders to answer STUN keepalives; otherwise it starves, the kernel
+  // drops keepalives, and the browser declares ICE failed (~15s) and drops the
+  // stream. Best-effort: never crashes; logs and continues if it can't apply.
   auto make_realtime = [](rtc::Thread* t, const char* tname) {
     if (t == nullptr) return;
-    t->Invoke<void>(RTC_FROM_HERE, [tname]() {
-      struct sched_param sp;
-      std::memset(&sp, 0, sizeof(sp));
-      sp.sched_priority = 20;  // modest RT priority, well below kernel threads
-      if (pthread_setschedparam(pthread_self(), SCHED_RR, &sp) != 0) {
-        RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=sched_rr_failed thread=" << tname
-                          << " prio=20 err=" << std::strerror(errno);
-      } else {
-        RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=sched_rr_applied thread=" << tname
-                          << " prio=20";
-      }
-    });
+    try {
+      t->Invoke<void>(RTC_FROM_HERE, [tname]() {
+        struct sched_param sp;
+        std::memset(&sp, 0, sizeof(sp));
+        sp.sched_priority = 20;  // modest RT priority, well below kernel threads
+        // pthread_setschedparam returns the error code directly and does NOT set
+        // errno — must use the return value, not errno, to report the failure.
+        int rc = pthread_setschedparam(pthread_self(), SCHED_RR, &sp);
+        if (rc != 0) {
+          RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=sched_rr_failed thread=" << tname
+                            << " prio=20 err=" << std::strerror(rc);
+        } else {
+          // LS_ERROR (not LS_INFO): OWT is set to kError severity which drops
+          // LS_INFO. This is informational, not a real error.
+          RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=sched_rr_applied thread=" << tname
+                            << " prio=20";
+        }
+      });
+    } catch (const std::exception& e) {
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=sched_rr_exception thread=" << tname
+                        << " err=" << e.what();
+    } catch (...) {
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=sched_rr_exception thread=" << tname
+                        << " err=unknown";
+    }
   };
   make_realtime(network_thread.get(), "network_thread");
 


### PR DESCRIPTION
## Make libwebrtc `network_thread` real-time (SCHED_RR) to prevent ICE keepalive starvation

### Why

On appliance nodes, `webrtc_server` runs alongside CPU-heavy transcoders and the inference engine. libwebrtc's `network_thread` — which handles **all** ICE STUN consent-freshness keepalives and media socket draining — runs at normal priority (`SCHED_OTHER`). Under load it gets starved of CPU: the Linux fair scheduler leaves it queued behind transcoders for hundreds of milliseconds at a time (observed `net_thr_runq_wait_ms` of 300ms+ even on lightly-loaded nodes, multiple seconds under real load).

When `network_thread` can't run, it can't answer the browser's STUN keepalives. After ~15s with no response the browser declares ICE **Failed** and tears down the stream — the exact production disconnect symptom on Ebay nodes.

This change promotes `network_thread` to `SCHED_RR` priority 20 at factory init, so it preempts the transcoders just long enough to answer STUN and drain sockets, then yields back. Priority 20 is modest — well below kernel threads. The change is best-effort and non-throwing: if the container lacks `CAP_SYS_NICE` it logs and continues (no crash, no behavior change).

### Validation

**From logs** (OpenSearch or `webrtc_server.log`) — confirm it applied at startup:

```bash
grep "sched_rr" /var/log/ambient/webrtc_server.log | tail -5
# Expect: [CONN-DIAG] event=sched_rr_applied thread=network_thread prio=20
# On failure:  [CONN-DIAG][ERROR] event=sched_rr_failed thread=network_thread prio=20 err=Operation not permitted
```

**From shell** — confirm the running thread's scheduling policy:

```bash
WS_PID=$(pgrep webrtc_server | head -1)
for tid in $(ls /proc/$WS_PID/task/); do
  [ "$(cat /proc/$WS_PID/task/$tid/comm 2>/dev/null)" = "network_thread" ] && chrt -p $tid
done
# Expect: scheduling policy: SCHED_RR, scheduling priority: 20
```

**Measure the impact** — run-queue wait per 10s window should drop after promotion:

```bash
WS_PID=$(pgrep webrtc_server | head -1)
NET_TID=$(for tid in $(ls /proc/$WS_PID/task/); do
  [ "$(cat /proc/$WS_PID/task/$tid/comm 2>/dev/null)" = "network_thread" ] && echo $tid && break
done)
PREV=$(awk '{print $2}' /proc/$WS_PID/task/$NET_TID/schedstat)
while true; do
  sleep 10
  CURR=$(awk '{print $2}' /proc/$WS_PID/task/$NET_TID/schedstat)
  echo "net_thr_runq_wait last 10s = $(( (CURR-PREV)/1000000 ))ms"
  PREV=$CURR
done
```

### Testing

Built and tested successfully on `owt-client-native` — the appliance image builds cleanly (OWT compiles with `-fno-exceptions`, so no try/catch is used).

Deployed and validated on the **mem-testing node (staging)**:

- Startup log shows `[CONN-DIAG] event=sched_rr_applied thread=network_thread prio=20`
- `chrt -p <network_thread tid>` confirms `SCHED_RR, priority 20` live on the running thread, while the main process stays `SCHED_OTHER` (only `network_thread` is elevated, as intended)
- No crashes or functional regressions — pure scheduling + logging change

<img width="1504" height="691" alt="SCR-20260706-sxad" src="https://github.com/user-attachments/assets/a563e899-ab92-43cc-a872-3c9bebc8507a" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Linux-only real-time scheduling on the WebRTC network thread affects ICE connectivity under load and depends on container capabilities; failure is logged but behavior reverts to prior starvation risk.
> 
> **Overview**
> On **Linux**, after the peer connection factory starts `network_thread`, the PR **promotes only that thread** to **`SCHED_RR` priority 20** via `pthread_setschedparam` on the thread’s own pthread (through `rtc::Thread::Invoke`), so ICE/STUN keepalives and socket work can preempt co-located CPU-heavy transcoders.
> 
> The change is **best-effort**: success or failure is logged under **`[CONN-DIAG]`** (`sched_rr_applied` / `sched_rr_failed` with `strerror(rc)`); there is no crash or fallback path if the process lacks permission (e.g. `CAP_SYS_NICE`). Supporting includes for POSIX scheduling and `RTC_LOG` are added; **worker** and **signaling** threads are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e42648db86b06df454d0be79c9ce31faa882844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->