### PR TITLE
Making network thread pri change flag driven

### DIFF
--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -11,6 +11,7 @@ bool GlobalConfiguration::hardware_acceleration_enabled_ = true;
 bool GlobalConfiguration::encoded_frame_ = false;
 bool GlobalConfiguration::dual_video_encoder_ = false;
 bool GlobalConfiguration::bwe_optimization_settings_enabled_ = false;
+bool GlobalConfiguration::network_thread_realtime_enabled_ = true;
 std::unique_ptr<AudioFrameGeneratorInterface>
     GlobalConfiguration::audio_frame_generator_ = nullptr;
 std::unique_ptr<VideoDecoderInterface>

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -163,7 +163,15 @@ void PeerConnectionDependencyFactory::
       }
     });
   };
-  make_realtime(network_thread.get(), "network_thread");
+  // ON by default fleet-wide; node config kill-switch (bridged from NodeConfig
+  // in main.cc) can disable it on a node where network_thread spins and pegs a
+  // core, without a binary rollback.
+  if (GlobalConfiguration::GetNetworkThreadRealtimeEnabled()) {
+    make_realtime(network_thread.get(), "network_thread");
+  } else {
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=sched_rr_skipped thread=network_thread"
+                      << " reason=disabled_by_config";
+  }
 #endif  // WEBRTC_LINUX
 
   // Use webrtc::VideoEn(De)coderFactory on iOS.

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -89,6 +89,22 @@ class GlobalConfiguration {
     return bwe_optimization_settings_enabled_;
   }
   /**
+   @brief Enable/disable promoting the libwebrtc network_thread to SCHED_RR
+   real-time scheduling. Enabled by default; can be turned off per node via
+   config where a spinning network_thread would peg a CPU core.
+   @param enabled Whether network_thread should run at real-time priority.
+   */
+  static void SetNetworkThreadRealtimeEnabled(bool enabled) {
+    network_thread_realtime_enabled_ = enabled;
+  }
+  /**
+   @brief This function gets whether network_thread real-time scheduling is enabled.
+   @return true or false.
+   */
+  static bool GetNetworkThreadRealtimeEnabled() {
+    return network_thread_realtime_enabled_;
+  }
+  /**
    @brief This function sets the audio input to be an instance of
    AudioFrameGeneratorInterface.
    @details When it is enabled, SDK will not capture audio from mic. This means
@@ -259,6 +275,10 @@ class GlobalConfiguration {
    * Default is false. If it is set to true, uses BWE optimization settings.
    */
   static bool bwe_optimization_settings_enabled_;
+  /**
+   * Default is true. If true, network_thread is promoted to SCHED_RR.
+   */
+  static bool network_thread_realtime_enabled_;
   static std::unique_ptr<AudioFrameGeneratorInterface> audio_frame_generator_;
   /**
    @brief This function returns flag indicating whether customized video decoder is enabled or not


### PR DESCRIPTION
Making Network Thread PRIORITY change behind flag 
Seeing on few Nodes webrtc_server core not recovering 100% cpu utilisation

REF:  https://ambient-ai.slack.com/archives/CMFA1TU7P/p1784293128609739?thread_ts=1784237162.829809&cid=CMFA1TU7P

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebRTC thread scheduling on Linux; disabling RT may worsen ICE/STUN keepalive behavior, while leaving it on was already the default behavior.
> 
> **Overview**
> Linux **network_thread** `SCHED_RR` promotion is no longer unconditional: it runs only when **`GlobalConfiguration::GetNetworkThreadRealtimeEnabled()`** is true (default **on**).
> 
> Adds **`SetNetworkThreadRealtimeEnabled` / `GetNetworkThreadRealtimeEnabled`** and static **`network_thread_realtime_enabled_`** so nodes can turn off real-time scheduling when a spinning **network_thread** pegs CPU, without redeploying a binary. When disabled, startup logs **`sched_rr_skipped`** with **`reason=disabled_by_config`** instead of calling **`make_realtime`**.
> 
> Comments reference wiring the kill-switch from **NodeConfig** in **`main.cc`**; that bridge is not in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 494ea770ac20769d835c676421380a5954197cd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->