### PR TITLE
Making def value of net thr change to false

### DIFF
--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -11,7 +11,7 @@ bool GlobalConfiguration::hardware_acceleration_enabled_ = true;
 bool GlobalConfiguration::encoded_frame_ = false;
 bool GlobalConfiguration::dual_video_encoder_ = false;
 bool GlobalConfiguration::bwe_optimization_settings_enabled_ = false;
-bool GlobalConfiguration::network_thread_realtime_enabled_ = true;
+bool GlobalConfiguration::network_thread_realtime_enabled_ = false;
 std::unique_ptr<AudioFrameGeneratorInterface>
     GlobalConfiguration::audio_frame_generator_ = nullptr;
 std::unique_ptr<VideoDecoderInterface>

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -90,8 +90,8 @@ class GlobalConfiguration {
   }
   /**
    @brief Enable/disable promoting the libwebrtc network_thread to SCHED_RR
-   real-time scheduling. Enabled by default; can be turned off per node via
-   config where a spinning network_thread would peg a CPU core.
+   real-time scheduling. Disabled by default; opt-in per node via config because
+   SCHED_RR can peg sometime CPU core in some cases.
    @param enabled Whether network_thread should run at real-time priority.
    */
   static void SetNetworkThreadRealtimeEnabled(bool enabled) {
@@ -276,7 +276,7 @@ class GlobalConfiguration {
    */
   static bool bwe_optimization_settings_enabled_;
   /**
-   * Default is true. If true, network_thread is promoted to SCHED_RR.
+   * Default is false. If true, network_thread is promoted to SCHED_RR.
    */
   static bool network_thread_realtime_enabled_;
   static std::unique_ptr<AudioFrameGeneratorInterface> audio_frame_generator_;


### PR DESCRIPTION
Making this net_thr_priority flag change to false because we are seeing issues on tiktok

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default WebRTC networking thread scheduling for all nodes without explicit config, which can affect latency/jitter under load; mitigated by existing per-node opt-in.
> 
> **Overview**
> **Turns off real-time scheduling for libwebrtc’s `network_thread` by default** by changing `GlobalConfiguration::network_thread_realtime_enabled_` from `true` to `false` in `globalconfiguration.cc`.
> 
> Header comments in `globalconfiguration.h` now describe the flag as **disabled by default** and **opt-in per node** (via `SetNetworkThreadRealtimeEnabled` / node config), because SCHED_RR can peg a CPU core. Deployments that relied on the old default will no longer promote `network_thread` unless they explicitly enable it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b12e12ebd5c1bf0a2335f1e49531a66cfc0d12d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->