### PR TITLE
Use GATHER_ONCE for P2P ICE to stop webrtc_server UDP socket leak

### DIFF
--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -12,6 +12,7 @@ bool GlobalConfiguration::encoded_frame_ = false;
 bool GlobalConfiguration::dual_video_encoder_ = false;
 bool GlobalConfiguration::bwe_optimization_settings_enabled_ = false;
 bool GlobalConfiguration::network_thread_realtime_enabled_ = false;
+bool GlobalConfiguration::ice_gather_once_enabled_ = true;
 std::unique_ptr<AudioFrameGeneratorInterface>
     GlobalConfiguration::audio_frame_generator_ = nullptr;
 std::unique_ptr<VideoDecoderInterface>

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -105,6 +105,27 @@ class GlobalConfiguration {
     return network_thread_realtime_enabled_;
   }
   /**
+   @brief Enable/disable GATHER_ONCE for P2P ICE candidate gathering.
+   @details Enabled by default. Under GATHER_CONTINUALLY the allocator
+   re-gathers on any interface that has no working connection and never
+   reclaims those ports, leaking a UDP socket per round until the socket-leak
+   watchdog kills the process. GATHER_ONCE is correct for a fixed-network
+   publisher that never roams. Disabling this restores GATHER_CONTINUALLY per
+   node — a kill-switch for a node that genuinely needs in-place re-gathering,
+   without a binary rollback.
+   @param enabled Whether ICE gathering should stop after the first round.
+   */
+  static void SetIceGatherOnceEnabled(bool enabled) {
+    ice_gather_once_enabled_ = enabled;
+  }
+  /**
+   @brief This function gets whether GATHER_ONCE is enabled for P2P ICE.
+   @return true or false.
+   */
+  static bool GetIceGatherOnceEnabled() {
+    return ice_gather_once_enabled_;
+  }
+  /**
    @brief This function sets the audio input to be an instance of
    AudioFrameGeneratorInterface.
    @details When it is enabled, SDK will not capture audio from mic. This means
@@ -279,6 +300,7 @@ class GlobalConfiguration {
    * Default is false. If true, network_thread is promoted to SCHED_RR.
    */
   static bool network_thread_realtime_enabled_;
+  static bool ice_gather_once_enabled_;
   static std::unique_ptr<AudioFrameGeneratorInterface> audio_frame_generator_;
   /**
    @brief This function returns flag indicating whether customized video decoder is enabled or not

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -105,21 +105,16 @@ class GlobalConfiguration {
     return network_thread_realtime_enabled_;
   }
   /**
-   @brief Enable/disable GATHER_ONCE for P2P ICE candidate gathering.
-   @details Enabled by default. Under GATHER_CONTINUALLY the allocator
-   re-gathers on any interface that has no working connection and never
-   reclaims those ports, leaking a UDP socket per round until the socket-leak
-   watchdog kills the process. GATHER_ONCE is correct for a fixed-network
-   publisher that never roams. Disabling this restores GATHER_CONTINUALLY per
-   node — a kill-switch for a node that genuinely needs in-place re-gathering,
-   without a binary rollback.
+   @brief Enable/disable GATHER_ONCE for P2P ICE gathering. Enabled by default;
+   disabling restores GATHER_CONTINUALLY, which leaks a UDP socket per re-gather
+   round on interfaces that never form a working connection.
    @param enabled Whether ICE gathering should stop after the first round.
    */
   static void SetIceGatherOnceEnabled(bool enabled) {
     ice_gather_once_enabled_ = enabled;
   }
   /**
-   @brief This function gets whether GATHER_ONCE is enabled for P2P ICE.
+   @brief Gets whether GATHER_ONCE is enabled for P2P ICE.
    @return true or false.
    */
   static bool GetIceGatherOnceEnabled() {

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -388,8 +388,11 @@ PeerConnectionChannelConfiguration P2PClient::GetPeerConnectionChannelConfigurat
   // }
   // TODO(jianlin): For publisher, peerconnection is created before UA info is received.
   // so signaling protocol change is needed if we would like to remove this HC.
+  // AMBIENT: HC kept, flipped to GATHER_ONCE. Continual gathering never completes, so
+  // the allocator re-gathers every 5 min and retains ~4 UDP sockets/peer/round (10k+ in
+  // 40h, killed by the socket-leak watchdog). Local-only; the appliance never roams.
   config.continual_gathering_policy =
-      PeerConnectionInterface::ContinualGatheringPolicy::GATHER_CONTINUALLY;
+      PeerConnectionInterface::ContinualGatheringPolicy::GATHER_ONCE;
 
   // See webrtc/api/peer_connection_interface.h for details on the options
   // https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-24#section-4.1.1

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -389,13 +389,9 @@ PeerConnectionChannelConfiguration P2PClient::GetPeerConnectionChannelConfigurat
   // }
   // TODO(jianlin): For publisher, peerconnection is created before UA info is received.
   // so signaling protocol change is needed if we would like to remove this HC.
-  // AMBIENT: HC kept, but the value is now flag-driven. Under GATHER_CONTINUALLY
-  // the allocator re-gathers on any interface with no working connection and
-  // never reclaims those ports — one leaked UDP socket per round (10k+ in 40h,
-  // killed by the socket-leak watchdog). GATHER_ONCE by default: this is a
-  // fixed-network publisher and never roams. The node-config kill-switch
-  // (bridged from NodeConfig in main.cc) restores the old behaviour without a
-  // binary rollback. Local-only setting; not signalled to the peer.
+  // AMBIENT: HC kept, value now flag-driven. GATHER_CONTINUALLY re-gathers on
+  // interfaces that never connect and never reclaims those ports - one leaked
+  // UDP socket per round. Local-only; not signalled to the peer.
   config.continual_gathering_policy =
       owt::base::GlobalConfiguration::GetIceGatherOnceEnabled()
           ? PeerConnectionInterface::ContinualGatheringPolicy::GATHER_ONCE

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -12,6 +12,7 @@
 #include "webrtc/rtc_base/task_queue.h"
 #include "talk/owt/sdk/base/eventtrigger.h"
 #include "talk/owt/sdk/base/stringutils.h"
+#include "talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h"
 #include "talk/owt/sdk/include/cpp/owt/base/stream.h"
 #include "talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h"
 #include "talk/owt/sdk/p2p/p2ppeerconnectionchannel.h"
@@ -388,11 +389,17 @@ PeerConnectionChannelConfiguration P2PClient::GetPeerConnectionChannelConfigurat
   // }
   // TODO(jianlin): For publisher, peerconnection is created before UA info is received.
   // so signaling protocol change is needed if we would like to remove this HC.
-  // AMBIENT: HC kept, flipped to GATHER_ONCE. Continual gathering never completes, so
-  // the allocator re-gathers every 5 min and retains ~4 UDP sockets/peer/round (10k+ in
-  // 40h, killed by the socket-leak watchdog). Local-only; the appliance never roams.
+  // AMBIENT: HC kept, but the value is now flag-driven. Under GATHER_CONTINUALLY
+  // the allocator re-gathers on any interface with no working connection and
+  // never reclaims those ports — one leaked UDP socket per round (10k+ in 40h,
+  // killed by the socket-leak watchdog). GATHER_ONCE by default: this is a
+  // fixed-network publisher and never roams. The node-config kill-switch
+  // (bridged from NodeConfig in main.cc) restores the old behaviour without a
+  // binary rollback. Local-only setting; not signalled to the peer.
   config.continual_gathering_policy =
-      PeerConnectionInterface::ContinualGatheringPolicy::GATHER_ONCE;
+      owt::base::GlobalConfiguration::GetIceGatherOnceEnabled()
+          ? PeerConnectionInterface::ContinualGatheringPolicy::GATHER_ONCE
+          : PeerConnectionInterface::ContinualGatheringPolicy::GATHER_CONTINUALLY;
 
   // See webrtc/api/peer_connection_interface.h for details on the options
   // https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-24#section-4.1.1


### PR DESCRIPTION
## Problem

Edge nodes across the fleet are being killed by the edge-management socket-leak watchdog:

```
[acs-aba-pdx-037] Killed webrtc_server due to UDP socket leak: 10173 sockets (threshold: 10000)
```

It fires on many customers (acs, spacex, ebay, tiktok), which points at a hard-coded default rather than anything deployment-specific.

## Root cause

`GetPeerConnectionChannelConfiguration()` hard-codes `GATHER_CONTINUALLY` for every peer connection.

Under that policy ICE gathering **never reaches "complete"**. The port allocator sessions stay alive for the life of the PeerConnection and re-gather on a 5-minute timer. Each round binds a fresh UDP socket per network interface, and the previous rounds' sockets are retained — so every long-lived viewer accrues sockets monotonically for as long as it stays connected. Note that once PeerConnection stops, then the sockets are cleaned up, so it occurs only for long lived peers.

Continual gathering exists for mobile clients that roam between networks (wifi → cellular). The appliance is a fixed-network publisher and never needs it.

## Evidence (edgelogs, `acs-aba-pdx-037`)

A single peer traced over 3h20m — a metronome, 8 candidates every 5 minutes, never stopping:

```
00:03:55  8     00:23:55  7     ...     03:03:55  8
00:08:55  8     00:28:55  8     ...     03:08:55  8
00:13:55  7     00:33:55  8     ...     03:13:55  8
                                     → 305 candidates, ONE viewer
```

Roughly 4 `local` (host) + 4 `stun` per round. The `stun` candidates are discovered through the existing host socket and cost nothing; the ~4 host candidates each bind a new UDP socket.

Over the 15h before the kill:

| Signal | Count | Reading |
|---|---|---|
| `local_candidate` | 28,648 | ~195 per peer |
| distinct peers | 147 | |
| `gathering_state` | 223 | **gathering never completes** — the fingerprint of `GATHER_CONTINUALLY` |
| peers with `create_offer` | 147 | |
| peers with `close_peer_connection` | 143 | teardown is healthy — peers are **not** leaking |

That last pair matters: this is *not* a leaked-PeerConnection bug. 147 opened, 143 closed; the `doCleanConnections` reaper works. The leak is inside each correctly-managed connection, which is why connection-count metrics show nothing wrong.

Process timeline for the failing run:

- restart `2026-07-29T10:35:37` (pid 1187)
- killed `2026-07-31T03:17:12` at 10,173 sockets — a **40-hour** climb
- restart `2026-07-31T03:17:19` (pid 81101)

Steady state was ~1,800 candidates/hr ≈ 900 new sockets/hr. Sockets *are* reclaimed when a viewer disconnects and the PC closes, so the ceiling is set by long-lived viewers — a browser tab left open on a stream accrues ~48 sockets/hour indefinitely.

## Change

One line: `GATHER_CONTINUALLY` → `GATHER_ONCE` in the P2P path, plus a comment recording why.

This is a **local-only** setting — it is not signaled to the peer and has no SDP representation. It governs how *we* gather our own candidates and changes nothing about the viewer's side. Browsers already behave this way: the JS API doesn't expose continual gathering, and Chrome/Firefox gather once per ICE generation, re-gathering only on an explicit `restartIce()`. No product-side change is needed.


## Trade-off

Existing connections no longer re-gather if the appliance's network changes mid-session (DHCP lease change, NIC flap). Recovery becomes viewer reconnect rather than in-place ICE recovery, which the staleness reaper already drives.

## Validation

Built and run locally as an A/B. Both binaries came from identical sources
except this one-line policy change, and were exercised under identical load.

**Setup** — full local stack, with a real browser peer rather than a synthetic
one: headless Chromium (Playwright) logs into the product UI, opens Video Walls,
and expands the live camera tile served by the appliance node. It held
`pcs=1 connected/connected` for the whole of both runs. Every 5 s, inside the
appliance container, the `webrtc_server` process's socket fd inodes from
`/proc/<pid>/fd` were intersected with `/proc/<pid>/net/udp` — so the count
covers only sockets owned by that process.

One peer, 53 samples per arm:

| elapsed | `GATHER_CONTINUALLY` udp | `GATHER_ONCE` udp |
|--------:|---------------:|-------------:|
| 34 s  | 2  | 2 |
| 95 s  | 6  | 2 |
| 136 s | 8  | 2 |
| 218 s | 12 | 2 |
| 279 s | **15** | **2** |

| | `GATHER_CONTINUALLY` | `GATHER_ONCE` |
|---|---|---|
| UDP sockets | 2 → **15**, monotonic | **2, flat for the whole run** |
| Total process fds | 73 → 86 (+13) | 69, unchanged |

Before: sockets accumulate with a *single* peer and are never returned while
that PeerConnection stays open. Total fds rose by exactly the same +13 as the
UDP count, confirming these are genuinely leaked descriptors rather than a
counting artifact. After: pinned at 2 under identical load.

This also confirms the "sockets are reclaimed when the PeerConnection stops"
claim above: the count returns to baseline on teardown in both arms.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core WebRTC ICE behavior for all P2P PCs; trade-off is no automatic re-gather on appliance network changes unless viewers reconnect or the flag is turned off.
> 
> **Overview**
> P2P peer connections no longer hard-code **`GATHER_CONTINUALLY`** for ICE gathering. **`GetPeerConnectionChannelConfiguration()`** now picks **`GATHER_ONCE`** or **`GATHER_CONTINUALLY`** from a new **`GlobalConfiguration`** toggle (**`SetIceGatherOnceEnabled` / `GetIceGatherOnceEnabled`**), which **defaults to enabled**.
> 
> That stops repeated re-gather rounds from binding extra host UDP sockets on long-lived viewers—behavior that was tripping edge **`webrtc_server`** socket-leak watchdogs. The setting is local-only (not signaled to peers). Disabling the flag restores continual gathering for cases that need in-session network roaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7bd60ecdb429768dcd54eb29f84be2322c1fe8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->