### PR TITLE
Add opt-in ICE interface ignore list to stop UDP socket leak

### DIFF
--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -12,6 +12,7 @@ bool GlobalConfiguration::encoded_frame_ = false;
 bool GlobalConfiguration::dual_video_encoder_ = false;
 bool GlobalConfiguration::bwe_optimization_settings_enabled_ = false;
 bool GlobalConfiguration::network_thread_realtime_enabled_ = false;
+std::vector<std::string> GlobalConfiguration::ice_network_ignore_list_;
 std::unique_ptr<AudioFrameGeneratorInterface>
     GlobalConfiguration::audio_frame_generator_ = nullptr;
 std::unique_ptr<VideoDecoderInterface>

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -254,6 +254,21 @@ void PeerConnectionDependencyFactory::
       webrtc::CreateBuiltinAudioDecoderFactory(), std::move(encoder_factory),
       std::move(decoder_factory), nullptr, nullptr);
   pc_factory_->AddRef();
+  // AMBIENT: if a node configures an ICE interface ignore list, stand up a
+  // NetworkManager that filters those interfaces out of enumeration. Built on
+  // the network thread because that is where the allocator will run it.
+  const auto& ignore_list = GlobalConfiguration::GetIceNetworkIgnoreList();
+  if (!ignore_list.empty() && network_thread) {
+    network_thread->Invoke<void>(RTC_FROM_HERE, [this, &ignore_list] {
+      ice_socket_factory_ = std::make_unique<rtc::BasicPacketSocketFactory>(
+          network_thread.get());
+      ice_network_manager_ = std::make_unique<rtc::BasicNetworkManager>();
+      ice_network_manager_->set_network_ignore_list(ignore_list);
+    });
+    // LS_ERROR because OWT runs at kError severity and drops LS_INFO.
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=ice_network_ignore_list_configured"
+                      << " count=" << ignore_list.size();
+  }
   RTC_LOG(LS_INFO) << "CreatePeerConnectionOnCurrentThread finished.";
 }
 
@@ -261,7 +276,16 @@ scoped_refptr<webrtc::PeerConnectionInterface>
 PeerConnectionDependencyFactory::CreatePeerConnectionOnCurrentThread(
     const webrtc::PeerConnectionInterface::RTCConfiguration& config,
     webrtc::PeerConnectionObserver* observer) {
-  return (pc_factory_->CreatePeerConnection(config, nullptr, nullptr, observer))
+  // AMBIENT: pass an interface-filtered PortAllocator when configured, so no
+  // ports are created on interfaces that can never carry a connection. Falls
+  // back to the factory default (nullptr) when the feature is off.
+  std::unique_ptr<cricket::PortAllocator> allocator;
+  if (ice_network_manager_ && ice_socket_factory_) {
+    allocator = std::make_unique<cricket::BasicPortAllocator>(
+        ice_network_manager_.get(), ice_socket_factory_.get());
+  }
+  return (pc_factory_->CreatePeerConnection(config, std::move(allocator),
+                                           nullptr, observer))
       .get();
 }
 void PeerConnectionDependencyFactory::CreatePeerConnectionFactory() {

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.h
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.h
@@ -12,6 +12,9 @@
 #endif
 #include "webrtc/sdk/media_constraints.h"
 #include "webrtc/rtc_base/bind.h"
+#include "webrtc/p2p/base/basic_packet_socket_factory.h"
+#include "webrtc/p2p/client/basic_port_allocator.h"
+#include "webrtc/rtc_base/network.h"
 namespace owt {
 namespace base {
 using webrtc::MediaStreamInterface;
@@ -86,6 +89,11 @@ class PeerConnectionDependencyFactory : public rtc::RefCountInterface {
   std::unique_ptr<rtc::Thread> worker_thread;
   std::unique_ptr<rtc::Thread> signaling_thread;
   std::unique_ptr<rtc::Thread> network_thread;
+  // Created on the network thread when an ICE network ignore list is
+  // configured; used to build a PortAllocator whose enumeration skips
+  // those interfaces. Null when the feature is off.
+  std::unique_ptr<rtc::BasicNetworkManager> ice_network_manager_;
+  std::unique_ptr<rtc::BasicPacketSocketFactory> ice_socket_factory_;
 #if defined(WEBRTC_WIN)
   bool render_hardware_acceleration_enabled_;  // Enabling HW acceleration for
                                                // VP8, H.264 & HEVC enc/dec

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -4,6 +4,8 @@
 #ifndef OWT_BASE_GLOBALCONFIGURATION_H_
 #define OWT_BASE_GLOBALCONFIGURATION_H_
 #include <memory>
+#include <string>
+#include <vector>
 #include "owt/base/framegeneratorinterface.h"
 #include "owt/base/videodecoderinterface.h"
 #if defined(WEBRTC_WIN)
@@ -103,6 +105,29 @@ class GlobalConfiguration {
    */
   static bool GetNetworkThreadRealtimeEnabled() {
     return network_thread_realtime_enabled_;
+  }
+  /**
+   @brief Set the list of local network interface names to exclude from ICE
+   candidate gathering.
+   @details Empty by default, which preserves existing behaviour. Interfaces on
+   this list are filtered out of network enumeration entirely, so no ports are
+   ever created on them. This exists because an interface that can never carry a
+   working connection is re-gathered indefinitely under continual gathering, and
+   its ports are never reclaimed - each round leaks a UDP socket. Opt in per
+   node via config; the correct list is deployment specific, and excluding an
+   interface removes it as a connectivity option for every peer.
+   @param interfaces Interface names to ignore, e.g. {"docker0", "br-lan"}.
+   */
+  static void SetIceNetworkIgnoreList(
+      const std::vector<std::string>& interfaces) {
+    ice_network_ignore_list_ = interfaces;
+  }
+  /**
+   @brief Get the ICE network ignore list.
+   @return Interface names excluded from ICE gathering; empty means none.
+   */
+  static const std::vector<std::string>& GetIceNetworkIgnoreList() {
+    return ice_network_ignore_list_;
   }
   /**
    @brief This function sets the audio input to be an instance of
@@ -279,6 +304,7 @@ class GlobalConfiguration {
    * Default is false. If true, network_thread is promoted to SCHED_RR.
    */
   static bool network_thread_realtime_enabled_;
+  static std::vector<std::string> ice_network_ignore_list_;
   static std::unique_ptr<AudioFrameGeneratorInterface> audio_frame_generator_;
   /**
    @brief This function returns flag indicating whether customized video decoder is enabled or not


### PR DESCRIPTION
Adds an opt-in ICE interface ignore list, so a node can stop gathering
candidates on interfaces that can never carry a working connection.

Off by default (`ice_network_ignore_list_` is empty) — no behaviour change
unless a node sets it. Same opt-in-per-node shape as
`SetNetworkThreadRealtimeEnabled` (#55/#56).

## Problem

Under `GATHER_CONTINUALLY`, an interface that never forms a working connection
is re-gathered indefinitely and its ports are never reclaimed. Each round binds
a fresh UDP socket that is never released, so `webrtc_server` climbs toward the
socket-leak watchdog threshold.

Measured on a local stack. The appliance container has two interfaces —
`eth0` (172.18.0.x, reaches the viewer) and `eth1` (172.19.0.x, which the
viewer has no route to). With one browser peer connected and the re-gather
interval accelerated to 5 s to make the effect visible in minutes:

| elapsed | `172.18.0.32` (media) | `172.19.0.11` (unreachable) |
|--------:|----------------------:|----------------------------:|
| 30 s  | 1 | 1 |
| 90 s  | **2** | 13 |
| 180 s | **2** | 31 |
| 256 s | **2** | **46** |

The interface carrying media is flat. **46 of 48 sockets are on the interface
that can never connect** — growth is exactly one socket per re-gather round,
entirely on the dead interface.

Mechanism: nothing on such a network is ever pruned, because
`BasicIceController::PruneConnections()` compares each connection against the
best one *on its own network* and requires `!best_conn->weak()`. A network where
nothing works has no non-weak best connection, so its connections are never
pruned; they keep pinging, stay `active()`, so `Connection::dead()` never
returns true, so the port's `connections_` never empties and
`Port::OnMessage`'s destroy gate never opens. Meanwhile the failed-network
re-gather timer adds another port every interval.

## Change

`GlobalConfiguration::SetIceNetworkIgnoreList()` takes interface names. When
non-empty, the factory builds a `BasicNetworkManager` with
`set_network_ignore_list()` and hands the PeerConnection a `BasicPortAllocator`
over it, instead of passing `nullptr` and letting the factory use its default.
Filtered interfaces never appear in enumeration, so no ports are created on
them and there is nothing to accumulate.

The network manager and socket factory are built on the network thread, since
that is where the allocator runs them.

## Validation

Same rig, same load, `GATHER_CONTINUALLY` still enabled, `eth1` on the ignore
list:

| | without ignore list | with `{"eth1"}` |
|---|---|---|
| `172.19.0.11` | 1 → **46** | **absent from enumeration** |
| `172.18.0.32` | 2 | 1 |
| total at ~230 s | 48, climbing | **1, flat** |

Peer held `pcs=1 connected/connected` for the whole run, so connectivity is
unaffected. Compiles clean (`ninja` exit 0, `libowt` relinked).

## Scope and caveats

- **This removes the trigger, not the mechanism.** The underlying libwebrtc
  behaviour is unchanged, so if an interface that *is* included later stops
  working (relay path dies, NAT rebinds, uplink flaps), growth resumes on it.
- **The correct list is deployment specific.** Excluding an interface removes
  it as a connectivity option for *every* peer, so it needs per-node
  validation. In this local test `eth1` also held the default route — excluding
  the default-route interface in production would remove srflx/relay
  candidates, which would be much worse than the leak.
- Unlike changing the gathering policy, this **keeps event-driven mobility
  recovery** (`OnNetworksChanged`) fully intact.

Needs the appliance-side `NodeConfig` wiring to actually set the list; that is
a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
