### PR TITLE
Log queue wait, queue depth and Clear timing on rtc::Thread

### DIFF
--- a/scripts/prepare_dev.py
+++ b/scripts/prepare_dev.py
@@ -20,6 +20,7 @@ LIBSRTP_PATH = os.path.join(THIRD_PARTY_PATH, 'libsrtp')
 LIBJPEG_TURBO_PATH = os.path.join(THIRD_PARTY_PATH, 'libjpeg_turbo')
 FFMPEG_PATH = os.path.join(THIRD_PARTY_PATH, 'ffmpeg')
 WEBRTC_OVERRIDES_PATH = os.path.join(THIRD_PARTY_PATH, 'webrtc_overrides')
+WEBRTC_PATH = os.path.join(THIRD_PARTY_PATH, 'webrtc')
 BUILD_PATH = os.path.join(HOME_PATH, 'build')
 TOOL_PATH = os.path.join(HOME_PATH, 'tools')
 BASE_PATH = os.path.join(HOME_PATH, 'base')
@@ -40,7 +41,8 @@ patchList = [
     ('0009-Export-WebRTC-symbols-on-iOS.patch', BUILD_PATH),
     ('0011-libjpeg_turbo-fix-for-CVE-2018-20330-and-19664.patch', LIBJPEG_TURBO_PATH),
     ('0013-Remove-unused-gni-for-av1-build.patch', THIRD_PARTY_PATH),
-    ('0014-Fix-missing-ffmpeg-configure-item-for-msvc-build.patch', FFMPEG_PATH)
+    ('0014-Fix-missing-ffmpeg-configure-item-for-msvc-build.patch', FFMPEG_PATH),
+    ('0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch', WEBRTC_PATH)
 ]
 
 def _patch(ignoreFailures=False):

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,4 +1,4 @@
-From b570857d2e0d200eb55c3d1f5584ddc94db184ab Mon Sep 17 00:00:00 2001
+From b8ccac5fc39964afb4a02d50139cde16352bcce6 Mon Sep 17 00:00:00 2001
 From: ambient <dev@ambient.ai>
 Date: Wed, 12 Aug 2026 13:59:41 +0000
 Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
@@ -8,12 +8,12 @@ message waited in the queue before it ran, how deep the queue was when it was po
 and how long Clear held the queue lock. Also fixes that line naming thread.cc as the
 origin of every Send and Invoke instead of the real caller.
 ---
- rtc_base/thread.cc        | 58 +++++++++++++++++++++++++++++++--------
+ rtc_base/thread.cc        | 63 +++++++++++++++++++++++++++++++--------
  rtc_base/thread_message.h |  4 ++-
- 2 files changed, 49 insertions(+), 13 deletions(-)
+ 2 files changed, 53 insertions(+), 14 deletions(-)
 
 diff --git a/rtc_base/thread.cc b/rtc_base/thread.cc
-index a8cb022fa9..7fdd17e8ec 100644
+index a8cb022fa9..3d36726062 100644
 --- a/rtc_base/thread.cc
 +++ b/rtc_base/thread.cc
 @@ -529,6 +529,7 @@ void Thread::Post(const Location& posted_from,
@@ -52,23 +52,28 @@ index a8cb022fa9..7fdd17e8ec 100644
      msg.posted_from = posted_from;
      msg.phandler = phandler;
      msg.message_id = id;
-@@ -665,9 +678,12 @@ void Thread::Dispatch(Message* pmsg) {
+@@ -664,10 +677,16 @@ void Thread::Dispatch(Message* pmsg) {
+   pmsg->phandler->OnMessage(pmsg);
    int64_t end_time = TimeMillis();
    int64_t diff = TimeDiff(end_time, start_time);
-   if (diff >= kSlowDispatchLoggingThreshold) {
+-  if (diff >= kSlowDispatchLoggingThreshold) {
 -    RTC_LOG(LS_INFO) << "Message took " << diff
 -                     << "ms to dispatch. Posted from: "
 -                     << pmsg->posted_from.ToString();
-+    // -1, not 0, so an unstamped message is not reported as an instant one.
-+    const int64_t queued_ms =
-+        pmsg->posted_ms != 0 ? TimeDiff(start_time, pmsg->posted_ms) : -1;
++  // -1, not 0, so an unstamped message is not reported as an instant one.
++  const int64_t queued_ms =
++      pmsg->posted_ms != 0 ? TimeDiff(start_time, pmsg->posted_ms) : -1;
++  // Either side crossing the bar is worth a line. Gating on dispatch alone hides the
++  // case this exists for: a message that waits a long time and then runs in microseconds.
++  if (diff >= kSlowDispatchLoggingThreshold ||
++      queued_ms >= kSlowDispatchLoggingThreshold) {
 +    RTC_LOG(LS_INFO) << "Message took " << diff << "ms to dispatch, after "
 +                     << queued_ms << "ms queued on thread " << name_
 +                     << ". Posted from: " << pmsg->posted_from.ToString();
    }
  }
  
-@@ -883,13 +899,16 @@ void Thread::Send(const Location& posted_from,
+@@ -883,13 +902,16 @@ void Thread::Send(const Location& posted_from,
                                                             this);
  #endif
    bool ready = false;
@@ -92,7 +97,7 @@ index a8cb022fa9..7fdd17e8ec 100644
  
    bool waited = false;
    crit_.Enter();
-@@ -977,8 +996,23 @@ bool Thread::IsProcessingMessagesForTesting() {
+@@ -977,8 +999,23 @@ bool Thread::IsProcessingMessagesForTesting() {
  void Thread::Clear(MessageHandler* phandler,
                     uint32_t id,
                     MessageList* removed) {

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,4 +1,4 @@
-From 15180315fb3564b35ef6ecabc73554adbeed3bce Mon Sep 17 00:00:00 2001
+From af79bebcadbd8f9120bb8d0de51ad7064772bdf8 Mon Sep 17 00:00:00 2001
 From: ambient <dev@ambient.ai>
 Date: Wed, 12 Aug 2026 13:59:41 +0000
 Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
@@ -8,26 +8,16 @@ message waited in the queue before it ran, how deep the queue was when it was po
 and how long Clear held the queue lock. Also fixes that line naming thread.cc as the
 origin of every Send and Invoke instead of the real caller.
 ---
- rtc_base/thread.cc        | 61 ++++++++++++++++++++++++++++++++++-----
- rtc_base/thread.h         |  3 ++
+ rtc_base/thread.cc        | 54 +++++++++++++++++++++++++++++++++------
+ rtc_base/thread.h         |  3 +++
  rtc_base/thread_message.h |  4 ++-
- 3 files changed, 59 insertions(+), 9 deletions(-)
+ 3 files changed, 52 insertions(+), 9 deletions(-)
 
 diff --git a/rtc_base/thread.cc b/rtc_base/thread.cc
-index a8cb022fa9..86cd4d72ff 100644
+index a8cb022fa9..d20060a622 100644
 --- a/rtc_base/thread.cc
 +++ b/rtc_base/thread.cc
-@@ -69,6 +69,9 @@ namespace rtc {
- namespace {
- 
- const int kSlowDispatchLoggingThreshold = 50;  // 50 ms
-+const size_t kDeepQueueLoggingThreshold = 16;
-+// Clear scans both queues under the lock Get and Post need. ~40ns/message measured.
-+const int kSlowClearLoggingThreshold = 5;  // 5 ms
- 
- class MessageHandlerWithTask final : public MessageHandler {
-  public:
-@@ -529,6 +532,7 @@ void Thread::Post(const Location& posted_from,
+@@ -529,6 +529,7 @@ void Thread::Post(const Location& posted_from,
    // Add the message to the end of the queue
    // Signal for the multiplexer to return
  
@@ -35,7 +25,7 @@ index a8cb022fa9..86cd4d72ff 100644
    {
      CritScope cs(&crit_);
      Message msg;
-@@ -536,7 +540,17 @@ void Thread::Post(const Location& posted_from,
+@@ -536,8 +537,16 @@ void Thread::Post(const Location& posted_from,
      msg.phandler = phandler;
      msg.message_id = id;
      msg.pdata = pdata;
@@ -44,16 +34,15 @@ index a8cb022fa9..86cd4d72ff 100644
 +    }
      messages_.push_back(msg);
 +    depth = messages_.size();   // free here; reading it later would retake the lock
-+  }
-+  // Every post past the bar, not just the crossing: one line per queued message is the
-+  // point, and this only runs at INFO on a node opted in for an investigation.
-+  if (depth >= kDeepQueueLoggingThreshold) {
-+    RTC_LOG(LS_INFO) << "Queue depth " << depth << " on thread " << name_
-+                     << " after posting from: " << posted_from.ToString();
    }
++  // Every post, so the count of posts per caller is itself the measurement. Only runs
++  // at INFO, on a node opted in for an investigation.
++  RTC_LOG(LS_INFO) << "Queue depth " << depth << " on thread " << name_
++                   << " after posting from: " << posted_from.ToString();
    WakeUpSocketServer();
  }
-@@ -577,6 +591,10 @@ void Thread::DoDelayPost(const Location& posted_from,
+ 
+@@ -577,6 +586,10 @@ void Thread::DoDelayPost(const Location& posted_from,
    {
      CritScope cs(&crit_);
      Message msg;
@@ -64,7 +53,7 @@ index a8cb022fa9..86cd4d72ff 100644
      msg.posted_from = posted_from;
      msg.phandler = phandler;
      msg.message_id = id;
-@@ -665,9 +683,12 @@ void Thread::Dispatch(Message* pmsg) {
+@@ -665,9 +678,12 @@ void Thread::Dispatch(Message* pmsg) {
    int64_t end_time = TimeMillis();
    int64_t diff = TimeDiff(end_time, start_time);
    if (diff >= kSlowDispatchLoggingThreshold) {
@@ -80,7 +69,7 @@ index a8cb022fa9..86cd4d72ff 100644
    }
  }
  
-@@ -883,13 +904,15 @@ void Thread::Send(const Location& posted_from,
+@@ -883,13 +899,15 @@ void Thread::Send(const Location& posted_from,
                                                             this);
  #endif
    bool ready = false;
@@ -98,7 +87,7 @@ index a8cb022fa9..86cd4d72ff 100644
  
    bool waited = false;
    crit_.Enter();
-@@ -950,9 +973,14 @@ void Thread::QueuedTaskHandler::OnMessage(Message* msg) {
+@@ -950,9 +968,14 @@ void Thread::QueuedTaskHandler::OnMessage(Message* msg) {
  }
  
  void Thread::PostTask(std::unique_ptr<webrtc::QueuedTask> task) {
@@ -114,7 +103,7 @@ index a8cb022fa9..86cd4d72ff 100644
         /*id=*/0, new ScopedMessageData<webrtc::QueuedTask>(std::move(task)));
  }
  
-@@ -977,8 +1005,25 @@ bool Thread::IsProcessingMessagesForTesting() {
+@@ -977,8 +1000,23 @@ bool Thread::IsProcessingMessagesForTesting() {
  void Thread::Clear(MessageHandler* phandler,
                     uint32_t id,
                     MessageList* removed) {
@@ -133,12 +122,10 @@ index a8cb022fa9..86cd4d72ff 100644
 +    done = TimeMillis();
 +  }
 +  // Logged after release: RTC_LOG would extend the hold it is reporting.
-+  if (scanned > 0 && TimeDiff(done, before_lock) >= kSlowClearLoggingThreshold) {
-+    RTC_LOG(LS_INFO) << "Clear on thread " << name_ << " waited "
-+                     << TimeDiff(acquired, before_lock) << "ms for the queue lock, then "
-+                     << "held it " << TimeDiff(done, acquired) << "ms scanning "
-+                     << scanned << " messages.";
-+  }
++  RTC_LOG(LS_INFO) << "Clear on thread " << name_ << " waited "
++                   << TimeDiff(acquired, before_lock) << "ms for the queue lock, then "
++                   << "held it " << TimeDiff(done, acquired) << "ms scanning "
++                   << scanned << " messages.";
  }
  
  bool Thread::ProcessMessages(int cmsLoop) {

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,4 +1,4 @@
-From dedadbcd1fd701e0d57a654c10f375a55ec951c6 Mon Sep 17 00:00:00 2001
+From f610372b5e9b7a92a486fbafb698dece4be804bf Mon Sep 17 00:00:00 2001
 From: ambient <dev@ambient.ai>
 Date: Wed, 12 Aug 2026 13:59:41 +0000
 Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
@@ -8,12 +8,13 @@ message waited in the queue before it ran, how deep the queue was when it was po
 and how long Clear held the queue lock. Also fixes that line naming thread.cc as the
 origin of every Send and Invoke instead of the real caller.
 ---
- rtc_base/thread.cc        | 93 +++++++++++++++++++++++++++++++++------
- rtc_base/thread_message.h |  4 +-
- 2 files changed, 83 insertions(+), 14 deletions(-)
+ rtc_base/thread.cc        | 106 +++++++++++++++++++++++++++++++++-----
+ rtc_base/thread.h         |   3 ++
+ rtc_base/thread_message.h |   4 +-
+ 3 files changed, 99 insertions(+), 14 deletions(-)
 
 diff --git a/rtc_base/thread.cc b/rtc_base/thread.cc
-index a8cb022fa9..efd2af551e 100644
+index a8cb022fa9..f5c4e7aa21 100644
 --- a/rtc_base/thread.cc
 +++ b/rtc_base/thread.cc
 @@ -10,6 +10,8 @@
@@ -25,20 +26,26 @@ index a8cb022fa9..efd2af551e 100644
  #if defined(WEBRTC_WIN)
  #include <comdef.h>
  #elif defined(WEBRTC_POSIX)
-@@ -69,6 +71,12 @@ namespace rtc {
+@@ -69,6 +71,18 @@ namespace rtc {
  namespace {
  
  const int kSlowDispatchLoggingThreshold = 50;  // 50 ms
 +// Measured on a live node: unguarded, Clear produced 2.7M lines in 2h (94% of all
 +// output) because it runs on every rtc::Thread whenever a MessageHandler is destroyed
 +// and almost always scans nothing. Depth added another 165k, one per Post.
++//
++// Output has to be bounded rather than proportional to load: a queue seen 13,696 deep
++// would otherwise emit 13,696 depth lines and as many queue-wait lines. Depth reports
++// at powers of two, and the queue-wait line is rate limited.
 +const size_t kDeepQueueLoggingThreshold = 16;
 +// Clear scans both queues under the lock Get and Post need. ~40ns/message measured.
 +const int kSlowClearLoggingThreshold = 5;  // 5 ms
++// At most one queue-wait line per thread per interval, however many messages are waiting.
++const int kQueueWaitLogIntervalMs = 1000;
  
  class MessageHandlerWithTask final : public MessageHandler {
   public:
-@@ -529,6 +537,7 @@ void Thread::Post(const Location& posted_from,
+@@ -529,6 +543,7 @@ void Thread::Post(const Location& posted_from,
    // Add the message to the end of the queue
    // Signal for the multiplexer to return
  
@@ -46,7 +53,7 @@ index a8cb022fa9..efd2af551e 100644
    {
      CritScope cs(&crit_);
      Message msg;
-@@ -536,7 +545,17 @@ void Thread::Post(const Location& posted_from,
+@@ -536,7 +551,17 @@ void Thread::Post(const Location& posted_from,
      msg.phandler = phandler;
      msg.message_id = id;
      msg.pdata = pdata;
@@ -56,15 +63,15 @@ index a8cb022fa9..efd2af551e 100644
      messages_.push_back(msg);
 +    depth = messages_.size();   // free here; reading it later would retake the lock
 +  }
-+  // Normal depth is 1-3, so this stays silent until a queue actually backs up. Logging
-+  // every post measured 165k lines in 2h on an idle node.
-+  if (depth >= kDeepQueueLoggingThreshold) {
++  // Normal depth is 1-3, so this stays silent until a queue actually backs up, and then
++  // reports only at powers of two: a 13,696-deep queue costs ~10 lines, not 13,696.
++  if (depth >= kDeepQueueLoggingThreshold && (depth & (depth - 1)) == 0) {
 +    RTC_LOG(LS_INFO) << "Queue depth " << depth << " on thread " << name_
 +                     << " after posting from: " << posted_from.ToString();
    }
    WakeUpSocketServer();
  }
-@@ -577,6 +596,10 @@ void Thread::DoDelayPost(const Location& posted_from,
+@@ -577,6 +602,10 @@ void Thread::DoDelayPost(const Location& posted_from,
    {
      CritScope cs(&crit_);
      Message msg;
@@ -75,7 +82,7 @@ index a8cb022fa9..efd2af551e 100644
      msg.posted_from = posted_from;
      msg.phandler = phandler;
      msg.message_id = id;
-@@ -656,18 +679,40 @@ void Thread::ClearInternal(MessageHandler* phandler,
+@@ -656,18 +685,47 @@ void Thread::ClearInternal(MessageHandler* phandler,
    delayed_messages_.reheap();
  }
  
@@ -112,15 +119,22 @@ index a8cb022fa9..efd2af551e 100644
 +      pmsg->posted_ms != 0 ? TimeDiff(start_time, pmsg->posted_ms) : -1;
 +  // Either side crossing the bar is worth a line. Gating on dispatch alone hides the
 +  // case this exists for: a message that waits a long time and then runs in microseconds.
-+  if (diff >= kSlowDispatchLoggingThreshold ||
-+      queued_ms >= kSlowDispatchLoggingThreshold) {
++  // A slow dispatch is rare and always worth a line. A long queue wait is not: when a
++  // queue backs up, every message in it waited, so log at most one per interval.
++  bool report_queue_wait = false;
++  if (queued_ms >= kSlowDispatchLoggingThreshold &&
++      TimeDiff(end_time, last_queue_wait_log_ms_) >= kQueueWaitLogIntervalMs) {
++    last_queue_wait_log_ms_ = end_time;
++    report_queue_wait = true;
++  }
++  if (diff >= kSlowDispatchLoggingThreshold || report_queue_wait) {
 +    RTC_LOG(LS_INFO) << "Message took " << diff << "ms to dispatch, after "
 +                     << queued_ms << "ms queued on thread " << name_
 +                     << ". Posted from: " << pmsg->posted_from.ToString();
    }
  }
  
-@@ -883,13 +928,16 @@ void Thread::Send(const Location& posted_from,
+@@ -883,13 +941,16 @@ void Thread::Send(const Location& posted_from,
                                                             this);
  #endif
    bool ready = false;
@@ -144,7 +158,7 @@ index a8cb022fa9..efd2af551e 100644
  
    bool waited = false;
    crit_.Enter();
-@@ -977,8 +1025,27 @@ bool Thread::IsProcessingMessagesForTesting() {
+@@ -977,8 +1038,27 @@ bool Thread::IsProcessingMessagesForTesting() {
  void Thread::Clear(MessageHandler* phandler,
                     uint32_t id,
                     MessageList* removed) {
@@ -174,6 +188,20 @@ index a8cb022fa9..efd2af551e 100644
  }
  
  bool Thread::ProcessMessages(int cmsLoop) {
+diff --git a/rtc_base/thread.h b/rtc_base/thread.h
+index 74aab623c8..0dd1704402 100644
+--- a/rtc_base/thread.h
++++ b/rtc_base/thread.h
+@@ -596,6 +596,9 @@ class RTC_LOCKABLE RTC_EXPORT Thread : public webrtc::TaskQueueBase {
+   // Runs webrtc::QueuedTask posted to the Thread.
+   QueuedTaskHandler queued_task_handler_;
+ 
++  // Rate limit for the queue-wait log. Only Dispatch touches it, on this thread.
++  int64_t last_queue_wait_log_ms_ = 0;
++
+   friend class ThreadManager;
+ 
+   RTC_DISALLOW_COPY_AND_ASSIGN(Thread);
 diff --git a/rtc_base/thread_message.h b/rtc_base/thread_message.h
 index 80824e29e5..404b96e395 100644
 --- a/rtc_base/thread_message.h

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,4 +1,4 @@
-From be03e1e22c889a41332b989d082a5f194bc392bd Mon Sep 17 00:00:00 2001
+From 15180315fb3564b35ef6ecabc73554adbeed3bce Mon Sep 17 00:00:00 2001
 From: ambient <dev@ambient.ai>
 Date: Wed, 12 Aug 2026 13:59:41 +0000
 Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
@@ -8,13 +8,13 @@ message waited in the queue before it ran, how deep the queue was when it was po
 and how long Clear held the queue lock. Also fixes that line naming thread.cc as the
 origin of every Send and Invoke instead of the real caller.
 ---
- rtc_base/thread.cc        | 60 +++++++++++++++++++++++++++++++++------
+ rtc_base/thread.cc        | 61 ++++++++++++++++++++++++++++++++++-----
  rtc_base/thread.h         |  3 ++
  rtc_base/thread_message.h |  4 ++-
- 3 files changed, 58 insertions(+), 9 deletions(-)
+ 3 files changed, 59 insertions(+), 9 deletions(-)
 
 diff --git a/rtc_base/thread.cc b/rtc_base/thread.cc
-index a8cb022fa9..966d6139ec 100644
+index a8cb022fa9..86cd4d72ff 100644
 --- a/rtc_base/thread.cc
 +++ b/rtc_base/thread.cc
 @@ -69,6 +69,9 @@ namespace rtc {
@@ -35,7 +35,7 @@ index a8cb022fa9..966d6139ec 100644
    {
      CritScope cs(&crit_);
      Message msg;
-@@ -536,7 +540,16 @@ void Thread::Post(const Location& posted_from,
+@@ -536,7 +540,17 @@ void Thread::Post(const Location& posted_from,
      msg.phandler = phandler;
      msg.message_id = id;
      msg.pdata = pdata;
@@ -45,14 +45,15 @@ index a8cb022fa9..966d6139ec 100644
      messages_.push_back(msg);
 +    depth = messages_.size();   // free here; reading it later would retake the lock
 +  }
-+  // Powers of two: logging every post while the queue stays deep is one line per post.
-+  if (depth >= kDeepQueueLoggingThreshold && (depth & (depth - 1)) == 0) {
++  // Every post past the bar, not just the crossing: one line per queued message is the
++  // point, and this only runs at INFO on a node opted in for an investigation.
++  if (depth >= kDeepQueueLoggingThreshold) {
 +    RTC_LOG(LS_INFO) << "Queue depth " << depth << " on thread " << name_
 +                     << " after posting from: " << posted_from.ToString();
    }
    WakeUpSocketServer();
  }
-@@ -577,6 +590,10 @@ void Thread::DoDelayPost(const Location& posted_from,
+@@ -577,6 +591,10 @@ void Thread::DoDelayPost(const Location& posted_from,
    {
      CritScope cs(&crit_);
      Message msg;
@@ -63,7 +64,7 @@ index a8cb022fa9..966d6139ec 100644
      msg.posted_from = posted_from;
      msg.phandler = phandler;
      msg.message_id = id;
-@@ -665,9 +682,12 @@ void Thread::Dispatch(Message* pmsg) {
+@@ -665,9 +683,12 @@ void Thread::Dispatch(Message* pmsg) {
    int64_t end_time = TimeMillis();
    int64_t diff = TimeDiff(end_time, start_time);
    if (diff >= kSlowDispatchLoggingThreshold) {
@@ -79,7 +80,7 @@ index a8cb022fa9..966d6139ec 100644
    }
  }
  
-@@ -883,13 +903,15 @@ void Thread::Send(const Location& posted_from,
+@@ -883,13 +904,15 @@ void Thread::Send(const Location& posted_from,
                                                             this);
  #endif
    bool ready = false;
@@ -97,7 +98,7 @@ index a8cb022fa9..966d6139ec 100644
  
    bool waited = false;
    crit_.Enter();
-@@ -950,9 +972,14 @@ void Thread::QueuedTaskHandler::OnMessage(Message* msg) {
+@@ -950,9 +973,14 @@ void Thread::QueuedTaskHandler::OnMessage(Message* msg) {
  }
  
  void Thread::PostTask(std::unique_ptr<webrtc::QueuedTask> task) {
@@ -113,7 +114,7 @@ index a8cb022fa9..966d6139ec 100644
         /*id=*/0, new ScopedMessageData<webrtc::QueuedTask>(std::move(task)));
  }
  
-@@ -977,8 +1004,25 @@ bool Thread::IsProcessingMessagesForTesting() {
+@@ -977,8 +1005,25 @@ bool Thread::IsProcessingMessagesForTesting() {
  void Thread::Clear(MessageHandler* phandler,
                     uint32_t id,
                     MessageList* removed) {

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,17 +1,12 @@
-From 02496470ef80e754c6d4ad38951d28f8f3e6d273 Mon Sep 17 00:00:00 2001
+From be03e1e22c889a41332b989d082a5f194bc392bd Mon Sep 17 00:00:00 2001
 From: ambient <dev@ambient.ai>
 Date: Wed, 12 Aug 2026 13:59:41 +0000
 Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
 
-libwebrtc times only OnMessage(), so a message delayed in the queue, behind a backlog,
-or by Clear holding the queue lock is indistinguishable from a slow handler.
-
-Message carries when it was queued and Dispatch subtracts it; Post reports queue depth
-at powers of two; Clear reports its lock wait and hold. PostTaskFrom keeps the caller
-location, which PostTask otherwise overwrites with thread.cc on every Send and Invoke.
-
-All at LS_INFO. The post-path clock read is gated on INFO; Clear is a cold path.
-Completion-based: a dispatch that never returns still logs nothing.
+Adds three logs beside the existing "Message took Nms to dispatch" line: how long the
+message waited in the queue before it ran, how deep the queue was when it was posted,
+and how long Clear held the queue lock. Also fixes that line naming thread.cc as the
+origin of every Send and Invoke instead of the real caller.
 ---
  rtc_base/thread.cc        | 60 +++++++++++++++++++++++++++++++++------
  rtc_base/thread.h         |  3 ++

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,4 +1,4 @@
-From af79bebcadbd8f9120bb8d0de51ad7064772bdf8 Mon Sep 17 00:00:00 2001
+From b570857d2e0d200eb55c3d1f5584ddc94db184ab Mon Sep 17 00:00:00 2001
 From: ambient <dev@ambient.ai>
 Date: Wed, 12 Aug 2026 13:59:41 +0000
 Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
@@ -8,13 +8,12 @@ message waited in the queue before it ran, how deep the queue was when it was po
 and how long Clear held the queue lock. Also fixes that line naming thread.cc as the
 origin of every Send and Invoke instead of the real caller.
 ---
- rtc_base/thread.cc        | 54 +++++++++++++++++++++++++++++++++------
- rtc_base/thread.h         |  3 +++
+ rtc_base/thread.cc        | 58 +++++++++++++++++++++++++++++++--------
  rtc_base/thread_message.h |  4 ++-
- 3 files changed, 52 insertions(+), 9 deletions(-)
+ 2 files changed, 49 insertions(+), 13 deletions(-)
 
 diff --git a/rtc_base/thread.cc b/rtc_base/thread.cc
-index a8cb022fa9..d20060a622 100644
+index a8cb022fa9..7fdd17e8ec 100644
 --- a/rtc_base/thread.cc
 +++ b/rtc_base/thread.cc
 @@ -529,6 +529,7 @@ void Thread::Post(const Location& posted_from,
@@ -69,41 +68,31 @@ index a8cb022fa9..d20060a622 100644
    }
  }
  
-@@ -883,13 +899,15 @@ void Thread::Send(const Location& posted_from,
+@@ -883,13 +899,16 @@ void Thread::Send(const Location& posted_from,
                                                             this);
  #endif
    bool ready = false;
 -  PostTask(
-+  // PostTaskFrom, so a blocking Invoke reports its own call site, not thread.cc.
-+  PostTaskFrom(
-       webrtc::ToQueuedTask([msg]() mutable { msg.phandler->OnMessage(&msg); },
-                            [this, &ready, current_thread] {
-                              CritScope cs(&crit_);
-                              ready = true;
-                              current_thread->socketserver()->WakeUp();
+-      webrtc::ToQueuedTask([msg]() mutable { msg.phandler->OnMessage(&msg); },
+-                           [this, &ready, current_thread] {
+-                             CritScope cs(&crit_);
+-                             ready = true;
+-                             current_thread->socketserver()->WakeUp();
 -                           }));
-+                           }),
-+      posted_from);
++  // Posted here rather than via PostTask, which stamps its own RTC_FROM_HERE and would
++  // make every blocking Invoke report thread.cc as its origin.
++  Post(posted_from, &queued_task_handler_, /*id=*/0,
++       new ScopedMessageData<webrtc::QueuedTask>(webrtc::ToQueuedTask(
++           [msg]() mutable { msg.phandler->OnMessage(&msg); },
++           [this, &ready, current_thread] {
++             CritScope cs(&crit_);
++             ready = true;
++             current_thread->socketserver()->WakeUp();
++           })));
  
    bool waited = false;
    crit_.Enter();
-@@ -950,9 +968,14 @@ void Thread::QueuedTaskHandler::OnMessage(Message* msg) {
- }
- 
- void Thread::PostTask(std::unique_ptr<webrtc::QueuedTask> task) {
-+  PostTaskFrom(std::move(task), RTC_FROM_HERE);
-+}
-+
-+void Thread::PostTaskFrom(std::unique_ptr<webrtc::QueuedTask> task,
-+                          const Location& posted_from) {
-   // Though Post takes MessageData by raw pointer (last parameter), it still
-   // takes it with ownership.
--  Post(RTC_FROM_HERE, &queued_task_handler_,
-+  Post(posted_from, &queued_task_handler_,
-        /*id=*/0, new ScopedMessageData<webrtc::QueuedTask>(std::move(task)));
- }
- 
-@@ -977,8 +1000,23 @@ bool Thread::IsProcessingMessagesForTesting() {
+@@ -977,8 +996,23 @@ bool Thread::IsProcessingMessagesForTesting() {
  void Thread::Clear(MessageHandler* phandler,
                     uint32_t id,
                     MessageList* removed) {
@@ -129,20 +118,6 @@ index a8cb022fa9..d20060a622 100644
  }
  
  bool Thread::ProcessMessages(int cmsLoop) {
-diff --git a/rtc_base/thread.h b/rtc_base/thread.h
-index 74aab623c8..8d0679507f 100644
---- a/rtc_base/thread.h
-+++ b/rtc_base/thread.h
-@@ -390,6 +390,9 @@ class RTC_LOCKABLE RTC_EXPORT Thread : public webrtc::TaskQueueBase {
- 
-   // From TaskQueueBase
-   void PostTask(std::unique_ptr<webrtc::QueuedTask> task) override;
-+  // As PostTask, but keeps the caller location instead of stamping thread.cc.
-+  void PostTaskFrom(std::unique_ptr<webrtc::QueuedTask> task,
-+                    const Location& posted_from);
-   void PostDelayedTask(std::unique_ptr<webrtc::QueuedTask> task,
-                        uint32_t milliseconds) override;
-   void Delete() override;
 diff --git a/rtc_base/thread_message.h b/rtc_base/thread_message.h
 index 80824e29e5..404b96e395 100644
 --- a/rtc_base/thread_message.h

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,0 +1,155 @@
+From 377ad4657b4bbec8b6d3f40fa141ad2ee19e0fb5 Mon Sep 17 00:00:00 2001
+From: ambient <dev@ambient.ai>
+Date: Wed, 12 Aug 2026 13:59:41 +0000
+Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
+
+The slow-dispatch line reports only how long OnMessage() ran, so every other way a
+message can be delayed is invisible and indistinguishable from a slow handler.
+
+Message now carries when it was queued, and Dispatch subtracts it, so a slow message
+is split into time spent waiting and time spent running. Post reports queue depth,
+which separates one slow handler from fifty messages backed up behind it. Clear reports
+how long it waited for the queue lock and how long it held it while scanning, because
+that stalls the thread without any dispatch running at all.
+
+All at LS_INFO, beside the existing line. The clock read in the post path is gated on
+INFO being enabled, so a default build pays a severity check. Clear is a cold path and
+is not gated.
+
+Still completion-based: a dispatch that never returns logs nothing here.
+---
+ rtc_base/thread.cc        | 48 ++++++++++++++++++++++++++++++++++++---
+ rtc_base/thread_message.h |  6 ++++-
+ 2 files changed, 50 insertions(+), 4 deletions(-)
+
+diff --git a/rtc_base/thread.cc b/rtc_base/thread.cc
+index a8cb022fa9..2846e4fc88 100644
+--- a/rtc_base/thread.cc
++++ b/rtc_base/thread.cc
+@@ -69,6 +69,12 @@ namespace rtc {
+ namespace {
+ 
+ const int kSlowDispatchLoggingThreshold = 50;  // 50 ms
++// Queue depth at post time worth remarking on. A single slow handler and fifty queued
++// messages both show up as a slow dispatch downstream; this separates them.
++const size_t kDeepQueueLoggingThreshold = 16;
++// Clear() scans messages_ and delayed_messages_ linearly while holding the same lock
++// Get() and Post() need, so a long one stalls the thread without any dispatch running.
++const int kSlowClearLoggingThreshold = 20;  // 20 ms
+ 
+ class MessageHandlerWithTask final : public MessageHandler {
+  public:
+@@ -529,6 +535,7 @@ void Thread::Post(const Location& posted_from,
+   // Add the message to the end of the queue
+   // Signal for the multiplexer to return
+ 
++  size_t depth = 0;
+   {
+     CritScope cs(&crit_);
+     Message msg;
+@@ -536,7 +543,16 @@ void Thread::Post(const Location& posted_from,
+     msg.phandler = phandler;
+     msg.message_id = id;
+     msg.pdata = pdata;
++    // Gated: this is the hot path, and the reader of it only logs at INFO anyway.
++    if (RTC_LOG_CHECK_LEVEL(LS_INFO)) {
++      msg.posted_ms = TimeMillis();
++    }
+     messages_.push_back(msg);
++    depth = messages_.size();   // free here; reading it later would retake the lock
++  }
++  if (depth >= kDeepQueueLoggingThreshold) {
++    RTC_LOG(LS_INFO) << "Queue depth " << depth << " on thread " << name_
++                     << " after posting from: " << posted_from.ToString();
+   }
+   WakeUpSocketServer();
+ }
+@@ -577,6 +593,11 @@ void Thread::DoDelayPost(const Location& posted_from,
+   {
+     CritScope cs(&crit_);
+     Message msg;
++    if (RTC_LOG_CHECK_LEVEL(LS_INFO)) {
++      // Its due time, not now: a delayed message is not waiting until it comes due, so
++      // measuring from the post would report the delay itself as queue wait.
++      msg.posted_ms = run_at_ms;
++    }
+     msg.posted_from = posted_from;
+     msg.phandler = phandler;
+     msg.message_id = id;
+@@ -665,9 +686,13 @@ void Thread::Dispatch(Message* pmsg) {
+   int64_t end_time = TimeMillis();
+   int64_t diff = TimeDiff(end_time, start_time);
+   if (diff >= kSlowDispatchLoggingThreshold) {
+-    RTC_LOG(LS_INFO) << "Message took " << diff
+-                     << "ms to dispatch. Posted from: "
+-                     << pmsg->posted_from.ToString();
++    // queued_ms is -1 when the sender skipped the clock read, so an unstamped message
++    // never reads as an instant one.
++    const int64_t queued_ms =
++        pmsg->posted_ms != 0 ? TimeDiff(start_time, pmsg->posted_ms) : -1;
++    RTC_LOG(LS_INFO) << "Message took " << diff << "ms to dispatch, after "
++                     << queued_ms << "ms queued on thread " << name_
++                     << ". Posted from: " << pmsg->posted_from.ToString();
+   }
+ }
+ 
+@@ -868,6 +893,9 @@ void Thread::Send(const Location& posted_from,
+   msg.phandler = phandler;
+   msg.message_id = id;
+   msg.pdata = pdata;
++  if (RTC_LOG_CHECK_LEVEL(LS_INFO)) {
++    msg.posted_ms = TimeMillis();
++  }
+   if (IsCurrent()) {
+     msg.phandler->OnMessage(&msg);
+     return;
+@@ -977,8 +1005,22 @@ bool Thread::IsProcessingMessagesForTesting() {
+ void Thread::Clear(MessageHandler* phandler,
+                    uint32_t id,
+                    MessageList* removed) {
++  // Timed on both sides. Waiting for the lock means somebody else is holding the queue;
++  // holding it long means this scan is what stalls everyone else. Neither shows up as a
++  // slow dispatch, because no dispatch is running. Cold path, so the clock reads are
++  // not worth gating.
++  const int64_t before_lock = TimeMillis();
+   CritScope cs(&crit_);
++  const int64_t acquired = TimeMillis();
++  const size_t scanned = messages_.size() + delayed_messages_.size();
+   ClearInternal(phandler, id, removed);
++  const int64_t done = TimeMillis();
++  if (TimeDiff(done, before_lock) >= kSlowClearLoggingThreshold) {
++    RTC_LOG(LS_INFO) << "Clear on thread " << name_ << " waited "
++                     << TimeDiff(acquired, before_lock) << "ms for the queue lock, then "
++                     << "held it " << TimeDiff(done, acquired) << "ms scanning "
++                     << scanned << " messages.";
++  }
+ }
+ 
+ bool Thread::ProcessMessages(int cmsLoop) {
+diff --git a/rtc_base/thread_message.h b/rtc_base/thread_message.h
+index 80824e29e5..3d9611d091 100644
+--- a/rtc_base/thread_message.h
++++ b/rtc_base/thread_message.h
+@@ -101,7 +101,7 @@ const uint32_t MQID_DISPOSE = static_cast<uint32_t>(-2);
+ // No destructor
+ 
+ struct Message {
+-  Message() : phandler(nullptr), message_id(0), pdata(nullptr) {}
++  Message() : phandler(nullptr), message_id(0), pdata(nullptr), posted_ms(0) {}
+   inline bool Match(MessageHandler* handler, uint32_t id) const {
+     return (handler == nullptr || handler == phandler) &&
+            (id == MQID_ANY || id == message_id);
+@@ -110,6 +110,10 @@ struct Message {
+   MessageHandler* phandler;
+   uint32_t message_id;
+   MessageData* pdata;
++  // TimeMillis() when this was queued, or 0 when INFO logging is off and the senders
++  // skipped the clock read. Dispatch subtracts it to report queue wait, which is the
++  // half of a slow message that the dispatch time alone does not explain.
++  int64_t posted_ms;
+ };
+ 
+ typedef std::list<Message> MessageList;
+-- 
+2.25.1
+

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,4 +1,4 @@
-From 377ad4657b4bbec8b6d3f40fa141ad2ee19e0fb5 Mon Sep 17 00:00:00 2001
+From 6201dc772a73977144e639f27586d982e5021c1c Mon Sep 17 00:00:00 2001
 From: ambient <dev@ambient.ai>
 Date: Wed, 12 Aug 2026 13:59:41 +0000
 Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
@@ -6,11 +6,15 @@ Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
 The slow-dispatch line reports only how long OnMessage() ran, so every other way a
 message can be delayed is invisible and indistinguishable from a slow handler.
 
-Message now carries when it was queued, and Dispatch subtracts it, so a slow message
-is split into time spent waiting and time spent running. Post reports queue depth,
-which separates one slow handler from fifty messages backed up behind it. Clear reports
-how long it waited for the queue lock and how long it held it while scanning, because
-that stalls the thread without any dispatch running at all.
+Message now carries when it was queued, and Dispatch subtracts it, so a slow message is
+split into time spent waiting and time spent running. Post reports queue depth, which
+separates one slow handler from a backlog behind it. Clear reports how long it waited
+for the queue lock and how long it held it while scanning, because that stalls the
+thread without any dispatch running at all.
+
+Depth is reported only at powers of two: the naive form logs once per post for as long
+as the queue stays deep, which measured 400k lines for 400k posts. Clear skips empty
+scans, which thread teardown produces constantly.
 
 All at LS_INFO, beside the existing line. The clock read in the post path is gated on
 INFO being enabled, so a default build pays a severity check. Clear is a cold path and
@@ -18,15 +22,15 @@ is not gated.
 
 Still completion-based: a dispatch that never returns logs nothing here.
 ---
- rtc_base/thread.cc        | 48 ++++++++++++++++++++++++++++++++++++---
+ rtc_base/thread.cc        | 53 ++++++++++++++++++++++++++++++++++++---
  rtc_base/thread_message.h |  6 ++++-
- 2 files changed, 50 insertions(+), 4 deletions(-)
+ 2 files changed, 55 insertions(+), 4 deletions(-)
 
 diff --git a/rtc_base/thread.cc b/rtc_base/thread.cc
-index a8cb022fa9..2846e4fc88 100644
+index a8cb022fa9..741e150921 100644
 --- a/rtc_base/thread.cc
 +++ b/rtc_base/thread.cc
-@@ -69,6 +69,12 @@ namespace rtc {
+@@ -69,6 +69,14 @@ namespace rtc {
  namespace {
  
  const int kSlowDispatchLoggingThreshold = 50;  // 50 ms
@@ -35,11 +39,13 @@ index a8cb022fa9..2846e4fc88 100644
 +const size_t kDeepQueueLoggingThreshold = 16;
 +// Clear() scans messages_ and delayed_messages_ linearly while holding the same lock
 +// Get() and Post() need, so a long one stalls the thread without any dispatch running.
-+const int kSlowClearLoggingThreshold = 20;  // 20 ms
++// Measured at roughly 40ns per message (400k scanned in 10ms), so this bar is about
++// 125k queued messages. Anything reaching it is already pathological.
++const int kSlowClearLoggingThreshold = 5;  // 5 ms
  
  class MessageHandlerWithTask final : public MessageHandler {
   public:
-@@ -529,6 +535,7 @@ void Thread::Post(const Location& posted_from,
+@@ -529,6 +537,7 @@ void Thread::Post(const Location& posted_from,
    // Add the message to the end of the queue
    // Signal for the multiplexer to return
  
@@ -47,7 +53,7 @@ index a8cb022fa9..2846e4fc88 100644
    {
      CritScope cs(&crit_);
      Message msg;
-@@ -536,7 +543,16 @@ void Thread::Post(const Location& posted_from,
+@@ -536,7 +545,19 @@ void Thread::Post(const Location& posted_from,
      msg.phandler = phandler;
      msg.message_id = id;
      msg.pdata = pdata;
@@ -58,13 +64,16 @@ index a8cb022fa9..2846e4fc88 100644
      messages_.push_back(msg);
 +    depth = messages_.size();   // free here; reading it later would retake the lock
 +  }
-+  if (depth >= kDeepQueueLoggingThreshold) {
++  // Only at powers of two. The naive form logs once per post for as long as the queue
++  // stays deep, which on a real backlog is one line per message; doubling reports the
++  // escalation in a handful of lines instead.
++  if (depth >= kDeepQueueLoggingThreshold && (depth & (depth - 1)) == 0) {
 +    RTC_LOG(LS_INFO) << "Queue depth " << depth << " on thread " << name_
 +                     << " after posting from: " << posted_from.ToString();
    }
    WakeUpSocketServer();
  }
-@@ -577,6 +593,11 @@ void Thread::DoDelayPost(const Location& posted_from,
+@@ -577,6 +598,11 @@ void Thread::DoDelayPost(const Location& posted_from,
    {
      CritScope cs(&crit_);
      Message msg;
@@ -76,7 +85,7 @@ index a8cb022fa9..2846e4fc88 100644
      msg.posted_from = posted_from;
      msg.phandler = phandler;
      msg.message_id = id;
-@@ -665,9 +686,13 @@ void Thread::Dispatch(Message* pmsg) {
+@@ -665,9 +691,13 @@ void Thread::Dispatch(Message* pmsg) {
    int64_t end_time = TimeMillis();
    int64_t diff = TimeDiff(end_time, start_time);
    if (diff >= kSlowDispatchLoggingThreshold) {
@@ -93,7 +102,7 @@ index a8cb022fa9..2846e4fc88 100644
    }
  }
  
-@@ -868,6 +893,9 @@ void Thread::Send(const Location& posted_from,
+@@ -868,6 +898,9 @@ void Thread::Send(const Location& posted_from,
    msg.phandler = phandler;
    msg.message_id = id;
    msg.pdata = pdata;
@@ -103,7 +112,7 @@ index a8cb022fa9..2846e4fc88 100644
    if (IsCurrent()) {
      msg.phandler->OnMessage(&msg);
      return;
-@@ -977,8 +1005,22 @@ bool Thread::IsProcessingMessagesForTesting() {
+@@ -977,8 +1010,22 @@ bool Thread::IsProcessingMessagesForTesting() {
  void Thread::Clear(MessageHandler* phandler,
                     uint32_t id,
                     MessageList* removed) {
@@ -117,7 +126,7 @@ index a8cb022fa9..2846e4fc88 100644
 +  const size_t scanned = messages_.size() + delayed_messages_.size();
    ClearInternal(phandler, id, removed);
 +  const int64_t done = TimeMillis();
-+  if (TimeDiff(done, before_lock) >= kSlowClearLoggingThreshold) {
++  if (scanned > 0 && TimeDiff(done, before_lock) >= kSlowClearLoggingThreshold) {
 +    RTC_LOG(LS_INFO) << "Clear on thread " << name_ << " waited "
 +                     << TimeDiff(acquired, before_lock) << "ms for the queue lock, then "
 +                     << "held it " << TimeDiff(done, acquired) << "ms scanning "

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,58 +1,38 @@
-From 83238d79431b933b6a6fdff64e26cd2c704f5938 Mon Sep 17 00:00:00 2001
+From 02496470ef80e754c6d4ad38951d28f8f3e6d273 Mon Sep 17 00:00:00 2001
 From: ambient <dev@ambient.ai>
 Date: Wed, 12 Aug 2026 13:59:41 +0000
 Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
 
-The slow-dispatch line reports only how long OnMessage() ran, so every other way a
-message can be delayed is invisible and indistinguishable from a slow handler.
+libwebrtc times only OnMessage(), so a message delayed in the queue, behind a backlog,
+or by Clear holding the queue lock is indistinguishable from a slow handler.
 
-Message now carries when it was queued, and Dispatch subtracts it, so a slow message is
-split into time spent waiting and time spent running. Post reports queue depth, which
-separates one slow handler from a backlog in front of it. Clear reports how long it
-waited for the queue lock and how long it held it while scanning, because that stalls
-the thread without any dispatch running at all.
+Message carries when it was queued and Dispatch subtracts it; Post reports queue depth
+at powers of two; Clear reports its lock wait and hold. PostTaskFrom keeps the caller
+location, which PostTask otherwise overwrites with thread.cc on every Send and Invoke.
 
-PostTask stamped its own RTC_FROM_HERE, so every task it queued -- which is every
-blocking Send and therefore every Invoke -- reported thread.cc as its origin. PostTaskFrom
-keeps the calling location, so the slow-dispatch line names the real call site on the
-paths that matter most.
-
-Depth is reported only at powers of two: the naive form logs once per post for as long
-as the queue stays deep, measured at 400k lines for 400k posts. Clear skips empty scans
-and logs after releasing the lock, since formatting a log while holding it would extend
-the hold time being reported.
-
-All at LS_INFO, beside the existing line. The clock read in the post path is gated on
-INFO being enabled, so a default build pays a severity check. Clear is a cold path and
-is not gated.
-
-Still completion-based: a dispatch that never returns logs nothing here.
+All at LS_INFO. The post-path clock read is gated on INFO; Clear is a cold path.
+Completion-based: a dispatch that never returns still logs nothing.
 ---
- rtc_base/thread.cc        | 77 +++++++++++++++++++++++++++++++++++----
- rtc_base/thread.h         |  5 +++
- rtc_base/thread_message.h |  6 ++-
- 3 files changed, 79 insertions(+), 9 deletions(-)
+ rtc_base/thread.cc        | 60 +++++++++++++++++++++++++++++++++------
+ rtc_base/thread.h         |  3 ++
+ rtc_base/thread_message.h |  4 ++-
+ 3 files changed, 58 insertions(+), 9 deletions(-)
 
 diff --git a/rtc_base/thread.cc b/rtc_base/thread.cc
-index a8cb022fa9..754f33453b 100644
+index a8cb022fa9..966d6139ec 100644
 --- a/rtc_base/thread.cc
 +++ b/rtc_base/thread.cc
-@@ -69,6 +69,14 @@ namespace rtc {
+@@ -69,6 +69,9 @@ namespace rtc {
  namespace {
  
  const int kSlowDispatchLoggingThreshold = 50;  // 50 ms
-+// Queue depth at post time worth remarking on. A single slow handler and fifty queued
-+// messages both show up as a slow dispatch downstream; this separates them.
 +const size_t kDeepQueueLoggingThreshold = 16;
-+// Clear() scans messages_ and delayed_messages_ linearly while holding the same lock
-+// Get() and Post() need, so a long one stalls the thread without any dispatch running.
-+// Measured at roughly 40ns per message (400k scanned in 10ms), so this bar is about
-+// 125k queued messages. Anything reaching it is already pathological.
++// Clear scans both queues under the lock Get and Post need. ~40ns/message measured.
 +const int kSlowClearLoggingThreshold = 5;  // 5 ms
  
  class MessageHandlerWithTask final : public MessageHandler {
   public:
-@@ -529,6 +537,7 @@ void Thread::Post(const Location& posted_from,
+@@ -529,6 +532,7 @@ void Thread::Post(const Location& posted_from,
    // Add the message to the end of the queue
    // Signal for the multiplexer to return
  
@@ -60,47 +40,42 @@ index a8cb022fa9..754f33453b 100644
    {
      CritScope cs(&crit_);
      Message msg;
-@@ -536,7 +545,19 @@ void Thread::Post(const Location& posted_from,
+@@ -536,7 +540,16 @@ void Thread::Post(const Location& posted_from,
      msg.phandler = phandler;
      msg.message_id = id;
      msg.pdata = pdata;
-+    // Gated: this is the hot path, and the reader of it only logs at INFO anyway.
-+    if (RTC_LOG_CHECK_LEVEL(LS_INFO)) {
++    if (RTC_LOG_CHECK_LEVEL(LS_INFO)) {   // gated: hot path
 +      msg.posted_ms = TimeMillis();
 +    }
      messages_.push_back(msg);
 +    depth = messages_.size();   // free here; reading it later would retake the lock
 +  }
-+  // Only at powers of two. The naive form logs once per post for as long as the queue
-+  // stays deep, which on a real backlog is one line per message; doubling reports the
-+  // escalation in a handful of lines instead.
++  // Powers of two: logging every post while the queue stays deep is one line per post.
 +  if (depth >= kDeepQueueLoggingThreshold && (depth & (depth - 1)) == 0) {
 +    RTC_LOG(LS_INFO) << "Queue depth " << depth << " on thread " << name_
 +                     << " after posting from: " << posted_from.ToString();
    }
    WakeUpSocketServer();
  }
-@@ -577,6 +598,11 @@ void Thread::DoDelayPost(const Location& posted_from,
+@@ -577,6 +590,10 @@ void Thread::DoDelayPost(const Location& posted_from,
    {
      CritScope cs(&crit_);
      Message msg;
 +    if (RTC_LOG_CHECK_LEVEL(LS_INFO)) {
-+      // Its due time, not now: a delayed message is not waiting until it comes due, so
-+      // measuring from the post would report the delay itself as queue wait.
++      // Due time, not now, so the delay is not counted as queue wait.
 +      msg.posted_ms = run_at_ms;
 +    }
      msg.posted_from = posted_from;
      msg.phandler = phandler;
      msg.message_id = id;
-@@ -665,9 +691,13 @@ void Thread::Dispatch(Message* pmsg) {
+@@ -665,9 +682,12 @@ void Thread::Dispatch(Message* pmsg) {
    int64_t end_time = TimeMillis();
    int64_t diff = TimeDiff(end_time, start_time);
    if (diff >= kSlowDispatchLoggingThreshold) {
 -    RTC_LOG(LS_INFO) << "Message took " << diff
 -                     << "ms to dispatch. Posted from: "
 -                     << pmsg->posted_from.ToString();
-+    // queued_ms is -1 when the sender skipped the clock read, so an unstamped message
-+    // never reads as an instant one.
++    // -1, not 0, so an unstamped message is not reported as an instant one.
 +    const int64_t queued_ms =
 +        pmsg->posted_ms != 0 ? TimeDiff(start_time, pmsg->posted_ms) : -1;
 +    RTC_LOG(LS_INFO) << "Message took " << diff << "ms to dispatch, after "
@@ -109,15 +84,12 @@ index a8cb022fa9..754f33453b 100644
    }
  }
  
-@@ -883,13 +913,18 @@ void Thread::Send(const Location& posted_from,
+@@ -883,13 +903,15 @@ void Thread::Send(const Location& posted_from,
                                                             this);
  #endif
    bool ready = false;
 -  PostTask(
-+  // PostTaskFrom, not PostTask: this is the path every blocking Invoke takes, and it is
-+  // the one whose call site matters. The Message queued here is the QueuedTask wrapper,
-+  // so its posted_ms is stamped by Post and measures the real queue wait; the msg copied
-+  // into the lambda below is never the one Dispatch sees.
++  // PostTaskFrom, so a blocking Invoke reports its own call site, not thread.cc.
 +  PostTaskFrom(
        webrtc::ToQueuedTask([msg]() mutable { msg.phandler->OnMessage(&msg); },
                             [this, &ready, current_thread] {
@@ -130,7 +102,7 @@ index a8cb022fa9..754f33453b 100644
  
    bool waited = false;
    crit_.Enter();
-@@ -950,9 +985,14 @@ void Thread::QueuedTaskHandler::OnMessage(Message* msg) {
+@@ -950,9 +972,14 @@ void Thread::QueuedTaskHandler::OnMessage(Message* msg) {
  }
  
  void Thread::PostTask(std::unique_ptr<webrtc::QueuedTask> task) {
@@ -146,16 +118,13 @@ index a8cb022fa9..754f33453b 100644
         /*id=*/0, new ScopedMessageData<webrtc::QueuedTask>(std::move(task)));
  }
  
-@@ -977,8 +1017,29 @@ bool Thread::IsProcessingMessagesForTesting() {
+@@ -977,8 +1004,25 @@ bool Thread::IsProcessingMessagesForTesting() {
  void Thread::Clear(MessageHandler* phandler,
                     uint32_t id,
                     MessageList* removed) {
 -  CritScope cs(&crit_);
 -  ClearInternal(phandler, id, removed);
-+  // Timed on both sides. Waiting for the lock means somebody else is holding the queue;
-+  // holding it long means this scan is what stalls everyone else. Neither shows up as a
-+  // slow dispatch, because no dispatch is running. Cold path, so the clock reads are
-+  // not worth gating.
++  // Waiting means somebody else holds the queue; holding means this scan stalls them.
 +  const int64_t before_lock = TimeMillis();
 +  int64_t acquired = 0;
 +  int64_t done = 0;
@@ -167,8 +136,7 @@ index a8cb022fa9..754f33453b 100644
 +    ClearInternal(phandler, id, removed);
 +    done = TimeMillis();
 +  }
-+  // Logged after the lock is released. RTC_LOG formats and takes the sink lock, so doing
-+  // it inside would extend the very hold time this is here to report.
++  // Logged after release: RTC_LOG would extend the hold it is reporting.
 +  if (scanned > 0 && TimeDiff(done, before_lock) >= kSlowClearLoggingThreshold) {
 +    RTC_LOG(LS_INFO) << "Clear on thread " << name_ << " waited "
 +                     << TimeDiff(acquired, before_lock) << "ms for the queue lock, then "
@@ -179,23 +147,21 @@ index a8cb022fa9..754f33453b 100644
  
  bool Thread::ProcessMessages(int cmsLoop) {
 diff --git a/rtc_base/thread.h b/rtc_base/thread.h
-index 74aab623c8..6e19aef4d8 100644
+index 74aab623c8..8d0679507f 100644
 --- a/rtc_base/thread.h
 +++ b/rtc_base/thread.h
-@@ -390,6 +390,11 @@ class RTC_LOCKABLE RTC_EXPORT Thread : public webrtc::TaskQueueBase {
+@@ -390,6 +390,9 @@ class RTC_LOCKABLE RTC_EXPORT Thread : public webrtc::TaskQueueBase {
  
    // From TaskQueueBase
    void PostTask(std::unique_ptr<webrtc::QueuedTask> task) override;
-+  // Same, but keeps the calling location instead of stamping PostTask's own. Without it
-+  // every task -- including every blocking Send/Invoke, which go through PostTask --
-+  // reports thread.cc as its origin, so the slow-dispatch log cannot name the call site.
++  // As PostTask, but keeps the caller location instead of stamping thread.cc.
 +  void PostTaskFrom(std::unique_ptr<webrtc::QueuedTask> task,
 +                    const Location& posted_from);
    void PostDelayedTask(std::unique_ptr<webrtc::QueuedTask> task,
                         uint32_t milliseconds) override;
    void Delete() override;
 diff --git a/rtc_base/thread_message.h b/rtc_base/thread_message.h
-index 80824e29e5..3d9611d091 100644
+index 80824e29e5..404b96e395 100644
 --- a/rtc_base/thread_message.h
 +++ b/rtc_base/thread_message.h
 @@ -101,7 +101,7 @@ const uint32_t MQID_DISPOSE = static_cast<uint32_t>(-2);
@@ -207,13 +173,11 @@ index 80824e29e5..3d9611d091 100644
    inline bool Match(MessageHandler* handler, uint32_t id) const {
      return (handler == nullptr || handler == phandler) &&
             (id == MQID_ANY || id == message_id);
-@@ -110,6 +110,10 @@ struct Message {
+@@ -110,6 +110,8 @@ struct Message {
    MessageHandler* phandler;
    uint32_t message_id;
    MessageData* pdata;
-+  // TimeMillis() when this was queued, or 0 when INFO logging is off and the senders
-+  // skipped the clock read. Dispatch subtracts it to report queue wait, which is the
-+  // half of a slow message that the dispatch time alone does not explain.
++  // TimeMillis() when queued, 0 if unstamped. Dispatch subtracts it for queue wait.
 +  int64_t posted_ms;
  };
  

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,4 +1,4 @@
-From 6201dc772a73977144e639f27586d982e5021c1c Mon Sep 17 00:00:00 2001
+From 83238d79431b933b6a6fdff64e26cd2c704f5938 Mon Sep 17 00:00:00 2001
 From: ambient <dev@ambient.ai>
 Date: Wed, 12 Aug 2026 13:59:41 +0000
 Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
@@ -8,13 +8,19 @@ message can be delayed is invisible and indistinguishable from a slow handler.
 
 Message now carries when it was queued, and Dispatch subtracts it, so a slow message is
 split into time spent waiting and time spent running. Post reports queue depth, which
-separates one slow handler from a backlog behind it. Clear reports how long it waited
-for the queue lock and how long it held it while scanning, because that stalls the
-thread without any dispatch running at all.
+separates one slow handler from a backlog in front of it. Clear reports how long it
+waited for the queue lock and how long it held it while scanning, because that stalls
+the thread without any dispatch running at all.
+
+PostTask stamped its own RTC_FROM_HERE, so every task it queued -- which is every
+blocking Send and therefore every Invoke -- reported thread.cc as its origin. PostTaskFrom
+keeps the calling location, so the slow-dispatch line names the real call site on the
+paths that matter most.
 
 Depth is reported only at powers of two: the naive form logs once per post for as long
-as the queue stays deep, which measured 400k lines for 400k posts. Clear skips empty
-scans, which thread teardown produces constantly.
+as the queue stays deep, measured at 400k lines for 400k posts. Clear skips empty scans
+and logs after releasing the lock, since formatting a log while holding it would extend
+the hold time being reported.
 
 All at LS_INFO, beside the existing line. The clock read in the post path is gated on
 INFO being enabled, so a default build pays a severity check. Clear is a cold path and
@@ -22,12 +28,13 @@ is not gated.
 
 Still completion-based: a dispatch that never returns logs nothing here.
 ---
- rtc_base/thread.cc        | 53 ++++++++++++++++++++++++++++++++++++---
- rtc_base/thread_message.h |  6 ++++-
- 2 files changed, 55 insertions(+), 4 deletions(-)
+ rtc_base/thread.cc        | 77 +++++++++++++++++++++++++++++++++++----
+ rtc_base/thread.h         |  5 +++
+ rtc_base/thread_message.h |  6 ++-
+ 3 files changed, 79 insertions(+), 9 deletions(-)
 
 diff --git a/rtc_base/thread.cc b/rtc_base/thread.cc
-index a8cb022fa9..741e150921 100644
+index a8cb022fa9..754f33453b 100644
 --- a/rtc_base/thread.cc
 +++ b/rtc_base/thread.cc
 @@ -69,6 +69,14 @@ namespace rtc {
@@ -102,30 +109,66 @@ index a8cb022fa9..741e150921 100644
    }
  }
  
-@@ -868,6 +898,9 @@ void Thread::Send(const Location& posted_from,
-   msg.phandler = phandler;
-   msg.message_id = id;
-   msg.pdata = pdata;
-+  if (RTC_LOG_CHECK_LEVEL(LS_INFO)) {
-+    msg.posted_ms = TimeMillis();
-+  }
-   if (IsCurrent()) {
-     msg.phandler->OnMessage(&msg);
-     return;
-@@ -977,8 +1010,22 @@ bool Thread::IsProcessingMessagesForTesting() {
+@@ -883,13 +913,18 @@ void Thread::Send(const Location& posted_from,
+                                                            this);
+ #endif
+   bool ready = false;
+-  PostTask(
++  // PostTaskFrom, not PostTask: this is the path every blocking Invoke takes, and it is
++  // the one whose call site matters. The Message queued here is the QueuedTask wrapper,
++  // so its posted_ms is stamped by Post and measures the real queue wait; the msg copied
++  // into the lambda below is never the one Dispatch sees.
++  PostTaskFrom(
+       webrtc::ToQueuedTask([msg]() mutable { msg.phandler->OnMessage(&msg); },
+                            [this, &ready, current_thread] {
+                              CritScope cs(&crit_);
+                              ready = true;
+                              current_thread->socketserver()->WakeUp();
+-                           }));
++                           }),
++      posted_from);
+ 
+   bool waited = false;
+   crit_.Enter();
+@@ -950,9 +985,14 @@ void Thread::QueuedTaskHandler::OnMessage(Message* msg) {
+ }
+ 
+ void Thread::PostTask(std::unique_ptr<webrtc::QueuedTask> task) {
++  PostTaskFrom(std::move(task), RTC_FROM_HERE);
++}
++
++void Thread::PostTaskFrom(std::unique_ptr<webrtc::QueuedTask> task,
++                          const Location& posted_from) {
+   // Though Post takes MessageData by raw pointer (last parameter), it still
+   // takes it with ownership.
+-  Post(RTC_FROM_HERE, &queued_task_handler_,
++  Post(posted_from, &queued_task_handler_,
+        /*id=*/0, new ScopedMessageData<webrtc::QueuedTask>(std::move(task)));
+ }
+ 
+@@ -977,8 +1017,29 @@ bool Thread::IsProcessingMessagesForTesting() {
  void Thread::Clear(MessageHandler* phandler,
                     uint32_t id,
                     MessageList* removed) {
+-  CritScope cs(&crit_);
+-  ClearInternal(phandler, id, removed);
 +  // Timed on both sides. Waiting for the lock means somebody else is holding the queue;
 +  // holding it long means this scan is what stalls everyone else. Neither shows up as a
 +  // slow dispatch, because no dispatch is running. Cold path, so the clock reads are
 +  // not worth gating.
 +  const int64_t before_lock = TimeMillis();
-   CritScope cs(&crit_);
-+  const int64_t acquired = TimeMillis();
-+  const size_t scanned = messages_.size() + delayed_messages_.size();
-   ClearInternal(phandler, id, removed);
-+  const int64_t done = TimeMillis();
++  int64_t acquired = 0;
++  int64_t done = 0;
++  size_t scanned = 0;
++  {
++    CritScope cs(&crit_);
++    acquired = TimeMillis();
++    scanned = messages_.size() + delayed_messages_.size();
++    ClearInternal(phandler, id, removed);
++    done = TimeMillis();
++  }
++  // Logged after the lock is released. RTC_LOG formats and takes the sink lock, so doing
++  // it inside would extend the very hold time this is here to report.
 +  if (scanned > 0 && TimeDiff(done, before_lock) >= kSlowClearLoggingThreshold) {
 +    RTC_LOG(LS_INFO) << "Clear on thread " << name_ << " waited "
 +                     << TimeDiff(acquired, before_lock) << "ms for the queue lock, then "
@@ -135,6 +178,22 @@ index a8cb022fa9..741e150921 100644
  }
  
  bool Thread::ProcessMessages(int cmsLoop) {
+diff --git a/rtc_base/thread.h b/rtc_base/thread.h
+index 74aab623c8..6e19aef4d8 100644
+--- a/rtc_base/thread.h
++++ b/rtc_base/thread.h
+@@ -390,6 +390,11 @@ class RTC_LOCKABLE RTC_EXPORT Thread : public webrtc::TaskQueueBase {
+ 
+   // From TaskQueueBase
+   void PostTask(std::unique_ptr<webrtc::QueuedTask> task) override;
++  // Same, but keeps the calling location instead of stamping PostTask's own. Without it
++  // every task -- including every blocking Send/Invoke, which go through PostTask --
++  // reports thread.cc as its origin, so the slow-dispatch log cannot name the call site.
++  void PostTaskFrom(std::unique_ptr<webrtc::QueuedTask> task,
++                    const Location& posted_from);
+   void PostDelayedTask(std::unique_ptr<webrtc::QueuedTask> task,
+                        uint32_t milliseconds) override;
+   void Delete() override;
 diff --git a/rtc_base/thread_message.h b/rtc_base/thread_message.h
 index 80824e29e5..3d9611d091 100644
 --- a/rtc_base/thread_message.h

--- a/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
+++ b/talk/owt/patches/0015-Log-queue-wait-depth-and-Clear-timing-on-rtc-Thread.patch
@@ -1,4 +1,4 @@
-From b8ccac5fc39964afb4a02d50139cde16352bcce6 Mon Sep 17 00:00:00 2001
+From dedadbcd1fd701e0d57a654c10f375a55ec951c6 Mon Sep 17 00:00:00 2001
 From: ambient <dev@ambient.ai>
 Date: Wed, 12 Aug 2026 13:59:41 +0000
 Subject: [PATCH] Log queue wait, queue depth and Clear timing on rtc::Thread
@@ -8,15 +8,37 @@ message waited in the queue before it ran, how deep the queue was when it was po
 and how long Clear held the queue lock. Also fixes that line naming thread.cc as the
 origin of every Send and Invoke instead of the real caller.
 ---
- rtc_base/thread.cc        | 63 +++++++++++++++++++++++++++++++--------
- rtc_base/thread_message.h |  4 ++-
- 2 files changed, 53 insertions(+), 14 deletions(-)
+ rtc_base/thread.cc        | 93 +++++++++++++++++++++++++++++++++------
+ rtc_base/thread_message.h |  4 +-
+ 2 files changed, 83 insertions(+), 14 deletions(-)
 
 diff --git a/rtc_base/thread.cc b/rtc_base/thread.cc
-index a8cb022fa9..3d36726062 100644
+index a8cb022fa9..efd2af551e 100644
 --- a/rtc_base/thread.cc
 +++ b/rtc_base/thread.cc
-@@ -529,6 +529,7 @@ void Thread::Post(const Location& posted_from,
+@@ -10,6 +10,8 @@
+ 
+ #include "rtc_base/thread.h"
+ 
++#include <cstdlib>
++
+ #if defined(WEBRTC_WIN)
+ #include <comdef.h>
+ #elif defined(WEBRTC_POSIX)
+@@ -69,6 +71,12 @@ namespace rtc {
+ namespace {
+ 
+ const int kSlowDispatchLoggingThreshold = 50;  // 50 ms
++// Measured on a live node: unguarded, Clear produced 2.7M lines in 2h (94% of all
++// output) because it runs on every rtc::Thread whenever a MessageHandler is destroyed
++// and almost always scans nothing. Depth added another 165k, one per Post.
++const size_t kDeepQueueLoggingThreshold = 16;
++// Clear scans both queues under the lock Get and Post need. ~40ns/message measured.
++const int kSlowClearLoggingThreshold = 5;  // 5 ms
+ 
+ class MessageHandlerWithTask final : public MessageHandler {
+  public:
+@@ -529,6 +537,7 @@ void Thread::Post(const Location& posted_from,
    // Add the message to the end of the queue
    // Signal for the multiplexer to return
  
@@ -24,7 +46,7 @@ index a8cb022fa9..3d36726062 100644
    {
      CritScope cs(&crit_);
      Message msg;
-@@ -536,8 +537,16 @@ void Thread::Post(const Location& posted_from,
+@@ -536,7 +545,17 @@ void Thread::Post(const Location& posted_from,
      msg.phandler = phandler;
      msg.message_id = id;
      msg.pdata = pdata;
@@ -33,15 +55,16 @@ index a8cb022fa9..3d36726062 100644
 +    }
      messages_.push_back(msg);
 +    depth = messages_.size();   // free here; reading it later would retake the lock
++  }
++  // Normal depth is 1-3, so this stays silent until a queue actually backs up. Logging
++  // every post measured 165k lines in 2h on an idle node.
++  if (depth >= kDeepQueueLoggingThreshold) {
++    RTC_LOG(LS_INFO) << "Queue depth " << depth << " on thread " << name_
++                     << " after posting from: " << posted_from.ToString();
    }
-+  // Every post, so the count of posts per caller is itself the measurement. Only runs
-+  // at INFO, on a node opted in for an investigation.
-+  RTC_LOG(LS_INFO) << "Queue depth " << depth << " on thread " << name_
-+                   << " after posting from: " << posted_from.ToString();
    WakeUpSocketServer();
  }
- 
-@@ -577,6 +586,10 @@ void Thread::DoDelayPost(const Location& posted_from,
+@@ -577,6 +596,10 @@ void Thread::DoDelayPost(const Location& posted_from,
    {
      CritScope cs(&crit_);
      Message msg;
@@ -52,7 +75,31 @@ index a8cb022fa9..3d36726062 100644
      msg.posted_from = posted_from;
      msg.phandler = phandler;
      msg.message_id = id;
-@@ -664,10 +677,16 @@ void Thread::Dispatch(Message* pmsg) {
+@@ -656,18 +679,40 @@ void Thread::ClearInternal(MessageHandler* phandler,
+   delayed_messages_.reheap();
+ }
+ 
++// REPRO ONLY -- not for production. AMBIENT_REPRO_SIGNALING_DELAY_MS>0 slows every
++// dispatch on signaling_thread, so a handful of streams builds the queue that a busy
++// production node builds with hundreds. Capped at 500ms; unset or 0 disables it.
++static int ReproSignalingDelayMs() {
++  static const int ms = []() {
++    const char* v = getenv("AMBIENT_REPRO_SIGNALING_DELAY_MS");
++    if (!v) return 0;
++    int n = atoi(v);
++    return n < 0 ? 0 : (n > 500 ? 500 : n);
++  }();
++  return ms;
++}
++
+ void Thread::Dispatch(Message* pmsg) {
+   TRACE_EVENT2("webrtc", "Thread::Dispatch", "src_file",
+                pmsg->posted_from.file_name(), "src_func",
+                pmsg->posted_from.function_name());
++  if (ReproSignalingDelayMs() > 0 && name_ == "signaling_thread") {
++    Thread::SleepMs(ReproSignalingDelayMs());
++  }
+   int64_t start_time = TimeMillis();
    pmsg->phandler->OnMessage(pmsg);
    int64_t end_time = TimeMillis();
    int64_t diff = TimeDiff(end_time, start_time);
@@ -73,7 +120,7 @@ index a8cb022fa9..3d36726062 100644
    }
  }
  
-@@ -883,13 +902,16 @@ void Thread::Send(const Location& posted_from,
+@@ -883,13 +928,16 @@ void Thread::Send(const Location& posted_from,
                                                             this);
  #endif
    bool ready = false;
@@ -97,7 +144,7 @@ index a8cb022fa9..3d36726062 100644
  
    bool waited = false;
    crit_.Enter();
-@@ -977,8 +999,23 @@ bool Thread::IsProcessingMessagesForTesting() {
+@@ -977,8 +1025,27 @@ bool Thread::IsProcessingMessagesForTesting() {
  void Thread::Clear(MessageHandler* phandler,
                     uint32_t id,
                     MessageList* removed) {
@@ -115,11 +162,15 @@ index a8cb022fa9..3d36726062 100644
 +    ClearInternal(phandler, id, removed);
 +    done = TimeMillis();
 +  }
-+  // Logged after release: RTC_LOG would extend the hold it is reporting.
-+  RTC_LOG(LS_INFO) << "Clear on thread " << name_ << " waited "
-+                   << TimeDiff(acquired, before_lock) << "ms for the queue lock, then "
-+                   << "held it " << TimeDiff(done, acquired) << "ms scanning "
-+                   << scanned << " messages.";
++  // Logged after release: RTC_LOG would extend the hold it is reporting. Skipping empty
++  // and fast scans is what keeps this from swamping the log -- teardown calls Clear on
++  // every thread in the process, and nearly all of those scan nothing.
++  if (scanned > 0 && TimeDiff(done, before_lock) >= kSlowClearLoggingThreshold) {
++    RTC_LOG(LS_INFO) << "Clear on thread " << name_ << " waited "
++                     << TimeDiff(acquired, before_lock) << "ms for the queue lock, then "
++                     << "held it " << TimeDiff(done, acquired) << "ms scanning "
++                     << scanned << " messages.";
++  }
  }
  
  bool Thread::ProcessMessages(int cmsLoop) {


### PR DESCRIPTION
Splits a slow message into its parts, so "the stall is in dispatch" can be confirmed or ruled out before anything more invasive is considered.
libwebrtc times only `OnMessage()`, so a message delayed in the queue, behind a backlog, or by `Clear` holding the queue lock looks identical to a slow handler. Adds three logs to tell them apart.

**1. Queue wait** — added to the existing slow-dispatch line, not a new one. `Message` records when it was queued; `Dispatch` subtracts it.

```
Message took 812ms to dispatch, after 4300ms queued on thread pc_thread.
    Posted from: peerconnectiondependencyfactory.cc:329(CreateLocalMediaStream)
```

**2. Queue depth** — one line per `Post`.

```
Queue depth 41 on thread pc_thread after posting from: ...factory.cc:329
```

**3. `Clear` timing** — one line per `Clear`, both sides of the lock. `Clear` scans both queues under the same lock `Get` and `Post` need, so a long one stalls the thread with no dispatch running.

```
Clear on thread pc_thread waited 0ms for the queue lock, then held it 118ms
    scanning 2400 messages.
```

**4. Fix** — `Send` reached the target via `PostTask`, which stamped its own `RTC_FROM_HERE`, so every blocking `Invoke` reported `Posted from: thread.cc`. `Send` now posts directly with the caller's location, which is what makes the logs above name anything on the `Invoke` paths.

All at `LS_INFO`. The post-path clock read is gated on INFO being enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live in third_party WebRTC's message-posting and blocking Send path on a hot threading core; mostly logging, but Send's Post path differs from PostTask and the repro env delay must stay disabled in production.
> 
> **Overview**
> Registers a new WebRTC patch in `prepare_dev.py` and applies **queue/backlog diagnostics** on `rtc::Thread` so slow-message logs can separate handler time from time spent waiting in the queue or blocked on `Clear`.
> 
> **`Message`** gains `posted_ms` (stamped on `Post`/`DoDelayPost` when INFO logging is enabled). The existing slow-dispatch line now includes **queue wait** and thread name, with queue-wait lines **rate-limited** per thread. **`Post`** logs **queue depth** only at power-of-two depths once depth ≥ 16. **`Clear`** logs lock wait/hold time and messages scanned when the operation is slow and non-empty.
> 
> **`Send`** no longer routes through `PostTask` (which overwrote `posted_from` with `thread.cc`); it posts the queued task with the **caller's** `Location`, so `Invoke`/`Send` stacks show real origins.
> 
> Also adds an opt-in **`AMBIENT_REPRO_SIGNALING_DELAY_MS`** env hook (capped, signaling thread only) to artificially slow dispatch for reproducing backlog behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f13546a433a430d7ef89e55e481009df5db9b7da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->