### PR TITLE
ice continual gathering policy behind feature flag

### DIFF
--- a/talk/owt/sdk/include/cpp/owt/base/clientconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/clientconfiguration.h
@@ -13,7 +13,8 @@ namespace base{
 struct ClientConfiguration {
   enum class CandidateNetworkPolicy : int { kAll = 1, kLowCost };
   ClientConfiguration()
-       : candidate_network_policy(CandidateNetworkPolicy::kAll) {}
+       : candidate_network_policy(CandidateNetworkPolicy::kAll),
+         continual_ice_gathering(true) {}
   /// List of ICE servers
   std::vector<IceServer> ice_servers;
   /**
@@ -23,6 +24,15 @@ struct ClientConfiguration {
    network experience. Default policy is collecting all candidates.
    */
   CandidateNetworkPolicy candidate_network_policy;
+  /**
+   @brief ICE gathering lifetime for each peer connection.
+   @details true (default) maps to GATHER_CONTINUALLY: the port allocator stays
+   alive and gathers new candidates on network changes for the lifetime of the
+   connection. false maps to GATHER_ONCE: candidates are gathered only during
+   initial negotiation; recovering from a network change then requires an ICE
+   restart.
+   */
+  bool continual_ice_gathering;
 };
 }
 }

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -389,7 +389,9 @@ PeerConnectionChannelConfiguration P2PClient::GetPeerConnectionChannelConfigurat
   // TODO(jianlin): For publisher, peerconnection is created before UA info is received.
   // so signaling protocol change is needed if we would like to remove this HC.
   config.continual_gathering_policy =
-      PeerConnectionInterface::ContinualGatheringPolicy::GATHER_CONTINUALLY;
+      configuration_.continual_ice_gathering
+          ? PeerConnectionInterface::ContinualGatheringPolicy::GATHER_CONTINUALLY
+          : PeerConnectionInterface::ContinualGatheringPolicy::GATHER_ONCE;
 
   // See webrtc/api/peer_connection_interface.h for details on the options
   // https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-24#section-4.1.1

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1501,10 +1501,12 @@ Json::Value P2PPeerConnectionChannel::UaInfo() {
   os[kUaOsNameKey] = sys_info.os.name;
   os[kUaOsVersionKey] = sys_info.os.version;
   // Capabilities and customized configuration
-  // TODO: currently default to support continual ICE gathering,
-  // Plan-B, and stream removable.
+  // TODO: currently default to support Plan-B and stream removable.
   Json::Value capabilities;
-  capabilities[kUaContinualGatheringKey] = true;
+  capabilities[kUaContinualGatheringKey] =
+      (configuration_.continual_gathering_policy ==
+       webrtc::PeerConnectionInterface::ContinualGatheringPolicy::
+           GATHER_CONTINUALLY);
   capabilities[kUaUnifiedPlanKey] = true;
   capabilities[kUaStreamRemovableKey] = true;
   capabilities[kUaIgnoresDataChannelAcksKey] = true;


### PR DESCRIPTION
## Make ICE gathering policy configurable

`P2PClient` hardcodes `GATHER_CONTINUALLY` for every peer connection. This adds
`ClientConfiguration::continual_ice_gathering` (default `true`, no behavior change)
so the embedding application can opt a node into `GATHER_ONCE`.

- `clientconfiguration.h`: new `continual_ice_gathering` field (default `true`)
- `p2pclient.cc`: map the field to `GATHER_CONTINUALLY` / `GATHER_ONCE` instead of hardcoding
- `p2ppeerconnectionchannel.cc`: advertise the `continualIceGathering` UA capability from the
  actual policy instead of always `true`

With `GATHER_ONCE`, candidate gathering stops after initial negotiation (no regathering on
network changes; recovery requires ICE restart). Trade-off: less STUN/TURN churn and
`onicecandidateerror` noise vs. no self-healing on network changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebRTC ICE lifecycle and P2P capability negotiation; wrong settings can hurt connectivity on network changes, though the default leaves behavior unchanged.
> 
> **Overview**
> **ICE gathering policy is no longer hardcoded** in `P2PClient`: embedders can choose continual vs one-shot gathering via `ClientConfiguration::continual_ice_gathering` (default **`true`**, preserving today’s behavior).
> 
> `p2pclient.cc` maps that flag to WebRTC’s `GATHER_CONTINUALLY` or `GATHER_ONCE` when building peer connection channel config. `p2ppeerconnectionchannel.cc` sets the `continualIceGathering` user-agent capability from the configured policy instead of always advertising `true`.
> 
> With **`false`**, gathering stops after initial negotiation—less STUN/TURN churn and `onicecandidateerror` noise, but network changes need an ICE restart rather than automatic regathering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05af29307a9832e520e072f8dd7610130986839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->