### PR TITLE
Run the unpublish transceiver walk on signaling_thread, behind a flag

### DIFF
--- a/talk/owt/sdk/base/peerconnectionchannel.h
+++ b/talk/owt/sdk/base/peerconnectionchannel.h
@@ -55,6 +55,9 @@ struct PeerConnectionChannelConfiguration
   std::vector<AudioEncodingParameters> audio;
   /// Indicate whether this PeerConnection is used for sending encoded frame.
   bool encoded_video_frame_;
+  /// Run the unpublish transceiver walk inside one Invoke on signaling_thread.
+  /// See ClientConfiguration::unpublish_on_signaling_thread.
+  bool unpublish_on_signaling_thread = false;
 };
 class PeerConnectionChannel : public webrtc::PeerConnectionObserver,
                               public webrtc::DataChannelObserver,

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.h
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.h
@@ -58,12 +58,9 @@ class PeerConnectionDependencyFactory : public rtc::RefCountInterface {
   // Returns current |pc_factory_|.
   rtc::scoped_refptr<PeerConnectionFactoryInterface> PeerConnectionFactory()
       const;
-  // The thread this factory handed to CreatePeerConnectionFactory as the
-  // signaling thread, i.e. the one every PeerConnection proxy method marshals
-  // to. Exposed so a caller holding several proxy handles can do its work in one
-  // Invoke instead of one marshal per call: SynchronousMethodCall::Invoke calls
-  // straight through when t->IsCurrent(), so proxy calls made inside such a
-  // lambda cost nothing extra.
+  // The thread every PeerConnection proxy method marshals to. Exposed so a caller
+  // holding several proxy handles can do its work in one Invoke rather than one
+  // marshal per call.
   rtc::Thread* SignalingThread() const { return signaling_thread.get(); }
   ~PeerConnectionDependencyFactory();
  protected:

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.h
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.h
@@ -58,6 +58,13 @@ class PeerConnectionDependencyFactory : public rtc::RefCountInterface {
   // Returns current |pc_factory_|.
   rtc::scoped_refptr<PeerConnectionFactoryInterface> PeerConnectionFactory()
       const;
+  // The thread this factory handed to CreatePeerConnectionFactory as the
+  // signaling thread, i.e. the one every PeerConnection proxy method marshals
+  // to. Exposed so a caller holding several proxy handles can do its work in one
+  // Invoke instead of one marshal per call: SynchronousMethodCall::Invoke calls
+  // straight through when t->IsCurrent(), so proxy calls made inside such a
+  // lambda cost nothing extra.
+  rtc::Thread* SignalingThread() const { return signaling_thread.get(); }
   ~PeerConnectionDependencyFactory();
  protected:
   explicit PeerConnectionDependencyFactory();

--- a/talk/owt/sdk/include/cpp/owt/base/clientconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/clientconfiguration.h
@@ -36,21 +36,9 @@ struct ClientConfiguration {
   bool continual_ice_gathering;
   /**
    @brief Which thread runs the unpublish transceiver walk in DrainPendingStreams.
-   @details false (default) leaves it on the calling thread, which is an appliance
-   thread-pool worker. Every step of the walk -- transceiver->sender(),
-   RemoveTrack, transceiver->Stop() -- is a PROXY method on a
-   BEGIN_SIGNALING_PROXY_MAP class, so each one marshals to signaling_thread and
-   blocks. The transceiver list only grows, since RemoveTrack stops a transceiver
-   but leaves it in place and nothing rebuilds the PeerConnection, so the walk
-   lengthens for the life of the connection. Measured on a production node whose
-   list had reached 462 entries: 131-307 marshals per teardown at 1239-3325us
-   each, 97.9% of a 445ms unpublish, and hangups taking 1-3s.
-
-   true wraps the same walk in one Invoke on signaling_thread. The loop body is
-   unchanged; only the thread it runs on differs. Inside that lambda every proxy
-   call short-circuits -- SynchronousMethodCall::Invoke calls the handler directly
-   when t->IsCurrent(), as does Thread::Send -- so the whole walk costs one
-   marshal instead of one per element.
+   @details false (default) walks it on the calling thread, where every step is a
+   signaling proxy call and marshals. true runs the same loop inside one
+   Invoke on signaling_thread.
    */
   bool unpublish_on_signaling_thread;
 };

--- a/talk/owt/sdk/include/cpp/owt/base/clientconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/clientconfiguration.h
@@ -14,7 +14,8 @@ struct ClientConfiguration {
   enum class CandidateNetworkPolicy : int { kAll = 1, kLowCost };
   ClientConfiguration()
        : candidate_network_policy(CandidateNetworkPolicy::kAll),
-         continual_ice_gathering(true) {}
+         continual_ice_gathering(true),
+         unpublish_on_signaling_thread(false) {}
   /// List of ICE servers
   std::vector<IceServer> ice_servers;
   /**
@@ -33,6 +34,25 @@ struct ClientConfiguration {
    restart.
    */
   bool continual_ice_gathering;
+  /**
+   @brief Which thread runs the unpublish transceiver walk in DrainPendingStreams.
+   @details false (default) leaves it on the calling thread, which is an appliance
+   thread-pool worker. Every step of the walk -- transceiver->sender(),
+   RemoveTrack, transceiver->Stop() -- is a PROXY method on a
+   BEGIN_SIGNALING_PROXY_MAP class, so each one marshals to signaling_thread and
+   blocks. The transceiver list only grows, since RemoveTrack stops a transceiver
+   but leaves it in place and nothing rebuilds the PeerConnection, so the walk
+   lengthens for the life of the connection. Measured on a production node whose
+   list had reached 462 entries: 131-307 marshals per teardown at 1239-3325us
+   each, 97.9% of a 445ms unpublish, and hangups taking 1-3s.
+
+   true wraps the same walk in one Invoke on signaling_thread. The loop body is
+   unchanged; only the thread it runs on differs. Inside that lambda every proxy
+   call short-circuits -- SynchronousMethodCall::Invoke calls the handler directly
+   when t->IsCurrent(), as does Thread::Send -- so the whole walk costs one
+   marshal instead of one per element.
+   */
+  bool unpublish_on_signaling_thread;
 };
 }
 }

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -392,6 +392,8 @@ PeerConnectionChannelConfiguration P2PClient::GetPeerConnectionChannelConfigurat
       configuration_.continual_ice_gathering
           ? PeerConnectionInterface::ContinualGatheringPolicy::GATHER_CONTINUALLY
           : PeerConnectionInterface::ContinualGatheringPolicy::GATHER_ONCE;
+  config.unpublish_on_signaling_thread =
+      configuration_.unpublish_on_signaling_thread;
 
   // See webrtc/api/peer_connection_interface.h for details on the options
   // https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-24#section-4.1.1

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1347,6 +1347,9 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
           };
 
       // LS_INFO (elevated to LS_ERROR — see file header note)
+      // TODO (atharva): Check if failed and stopped transceivers are 
+      // growing at high rate and should we clean them up as well to 
+      // reduce interations of for loop.
       auto log_unpublish = [&] {
         RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_unpublish peerid=" << remote_id_
                           << " on_signaling_thread="

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1302,27 +1302,52 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       scoped_refptr<webrtc::MediaStreamInterface> media_stream =
           stream->MediaStream();
       RTC_CHECK(temp_pc_);
-      for (const auto& track : media_stream->GetAudioTracks()) {
-        const auto& transceivers = temp_pc_->GetTransceivers();
-        for (auto& transceiver : transceivers) {
-          const auto& ttrack = transceiver->sender()->track();
-          if (ttrack != nullptr && ttrack->id() == track->id()) {
-            temp_pc_->RemoveTrack(transceiver->sender());
-            transceiver->Stop();
-            break;
+      // Every call in this walk -- transceiver->sender(), RemoveTrack,
+      // transceiver->Stop() -- is a PROXY method on a BEGIN_SIGNALING_PROXY_MAP class,
+      // so on a pool worker each one marshals to signaling_thread and blocks. The
+      // transceiver list only grows: RemoveTrack stops a transceiver but leaves it in
+      // place, and nothing rebuilds the PeerConnection. Measured at 131-307 marshals
+      // per teardown, 1239-3325us each, 97.9% of a 445ms unpublish.
+      //
+      // Running the identical loop inside one Invoke on signaling_thread costs one
+      // marshal instead: SynchronousMethodCall::Invoke calls the handler directly when
+      // t->IsCurrent(), as does Thread::Send, so every proxy call inside the lambda
+      // short-circuits. Behind a flag because it moves where the loop executes.
+      auto unpublish_all = [&] {
+        for (const auto& track : media_stream->GetAudioTracks()) {
+          for (auto& transceiver : temp_pc_->GetTransceivers()) {
+            const auto& ttrack = transceiver->sender()->track();
+            if (ttrack != nullptr && ttrack->id() == track->id()) {
+              temp_pc_->RemoveTrack(transceiver->sender());
+              transceiver->Stop();
+              break;
+            }
           }
         }
-      }
-      for (const auto& track : media_stream->GetVideoTracks()) {
-        const auto& transceivers = temp_pc_->GetTransceivers();
-        for (auto& transceiver : transceivers) {
-          const auto& ttrack = transceiver->sender()->track();
-          if (ttrack != nullptr && ttrack->id() == track->id()) {
-            temp_pc_->RemoveTrack(transceiver->sender());
-            transceiver->Stop();
-            break;
+        for (const auto& track : media_stream->GetVideoTracks()) {
+          for (auto& transceiver : temp_pc_->GetTransceivers()) {
+            const auto& ttrack = transceiver->sender()->track();
+            if (ttrack != nullptr && ttrack->id() == track->id()) {
+              temp_pc_->RemoveTrack(transceiver->sender());
+              transceiver->Stop();
+              break;
+            }
           }
         }
+      };
+      // Same singleton PeerConnectionChannel assigns to factory_, which is private in
+      // the base class.
+      PeerConnectionDependencyFactory* dependency_factory =
+          configuration_.unpublish_on_signaling_thread
+              ? PeerConnectionDependencyFactory::Get()
+              : nullptr;
+      rtc::Thread* signaling_thread = dependency_factory != nullptr
+                                          ? dependency_factory->SignalingThread()
+                                          : nullptr;
+      if (signaling_thread != nullptr && !signaling_thread->IsCurrent()) {
+        signaling_thread->Invoke<void>(RTC_FROM_HERE, unpublish_all);
+      } else {
+        unpublish_all();
       }
     }
   }

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1302,41 +1302,6 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       scoped_refptr<webrtc::MediaStreamInterface> media_stream =
           stream->MediaStream();
       RTC_CHECK(temp_pc_);
-      // Every call in this walk -- transceiver->sender(), RemoveTrack,
-      // transceiver->Stop() -- is a PROXY method on a BEGIN_SIGNALING_PROXY_MAP class,
-      // so on a pool worker each one marshals to signaling_thread and blocks. The
-      // transceiver list only grows: RemoveTrack stops a transceiver but leaves it in
-      // place, and nothing rebuilds the PeerConnection. Measured at 131-307 marshals
-      // per teardown, 1239-3325us each, 97.9% of a 445ms unpublish.
-      //
-      // Running the identical loop inside one Invoke on signaling_thread costs one
-      // marshal instead: SynchronousMethodCall::Invoke calls the handler directly when
-      // t->IsCurrent(), as does Thread::Send, so every proxy call inside the lambda
-      // short-circuits. Behind a flag because it moves where the loop executes.
-      auto unpublish_all = [&] {
-        for (const auto& track : media_stream->GetAudioTracks()) {
-          for (auto& transceiver : temp_pc_->GetTransceivers()) {
-            const auto& ttrack = transceiver->sender()->track();
-            if (ttrack != nullptr && ttrack->id() == track->id()) {
-              temp_pc_->RemoveTrack(transceiver->sender());
-              transceiver->Stop();
-              break;
-            }
-          }
-        }
-        for (const auto& track : media_stream->GetVideoTracks()) {
-          for (auto& transceiver : temp_pc_->GetTransceivers()) {
-            const auto& ttrack = transceiver->sender()->track();
-            if (ttrack != nullptr && ttrack->id() == track->id()) {
-              temp_pc_->RemoveTrack(transceiver->sender());
-              transceiver->Stop();
-              break;
-            }
-          }
-        }
-      };
-      // Same singleton PeerConnectionChannel assigns to factory_, which is private in
-      // the base class.
       PeerConnectionDependencyFactory* dependency_factory =
           configuration_.unpublish_on_signaling_thread
               ? PeerConnectionDependencyFactory::Get()
@@ -1344,10 +1309,86 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       rtc::Thread* signaling_thread = dependency_factory != nullptr
                                           ? dependency_factory->SignalingThread()
                                           : nullptr;
-      if (signaling_thread != nullptr && !signaling_thread->IsCurrent()) {
-        signaling_thread->Invoke<void>(RTC_FROM_HERE, unpublish_all);
-      } else {
-        unpublish_all();
+      const bool hop = signaling_thread != nullptr && !signaling_thread->IsCurrent();
+
+      size_t n_transceivers = 0;
+      int scanned = 0, hit_index = -1;
+      int trackless_before_hit = 0, stopped_before_hit = 0;
+
+      // Every step here is a signaling proxy call, so off-thread each one marshals.
+      // Running unpublish_track() on signaling_thread makes the whole walk a single hop.
+      auto unpublish_track =
+          [&](const rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>& track) {
+            RTC_DCHECK(signaling_thread != nullptr && signaling_thread->IsCurrent());
+            // Per track, not cumulative: a miss must leave hit_index at -1 rather
+            // than inheriting the previous track's hit.
+            scanned = trackless_before_hit = stopped_before_hit = 0;
+            hit_index = -1;
+            const auto& transceivers = temp_pc_->GetTransceivers();
+            n_transceivers = transceivers.size();
+            int index = 0;
+            for (auto& transceiver : transceivers) {
+              const auto& ttrack = transceiver->sender()->track();
+              if (ttrack == nullptr) {
+                ++trackless_before_hit;
+              }
+              if (transceiver->stopped()) {
+                ++stopped_before_hit;
+              }
+              if (ttrack != nullptr && ttrack->id() == track->id()) {
+                hit_index = index;
+                temp_pc_->RemoveTrack(transceiver->sender());
+                transceiver->Stop();
+                break;
+              }
+              ++index;
+            }
+            scanned = index;
+          };
+
+      // LS_INFO (elevated to LS_ERROR — see file header note)
+      auto log_unpublish = [&] {
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_unpublish peerid=" << remote_id_
+                          << " on_signaling_thread="
+                          << configuration_.unpublish_on_signaling_thread
+                          << " transceivers=" << n_transceivers
+                          << " scanned=" << scanned
+                          << " hit_index=" << hit_index
+                          << " trackless_before_hit=" << trackless_before_hit
+                          << " stopped_before_hit=" << stopped_before_hit;
+      };
+
+      for (const auto& track : media_stream->GetAudioTracks()) {
+        if (hop) {
+          signaling_thread->Invoke<void>(RTC_FROM_HERE, [&] { unpublish_track(track); });
+          log_unpublish();
+          continue;
+        }
+        const auto& transceivers = temp_pc_->GetTransceivers();
+        for (auto& transceiver : transceivers) {
+          const auto& ttrack = transceiver->sender()->track();
+          if (ttrack != nullptr && ttrack->id() == track->id()) {
+            temp_pc_->RemoveTrack(transceiver->sender());
+            transceiver->Stop();
+            break;
+          }
+        }
+      }
+      for (const auto& track : media_stream->GetVideoTracks()) {
+        if (hop) {
+          signaling_thread->Invoke<void>(RTC_FROM_HERE, [&] { unpublish_track(track); });
+          log_unpublish();
+          continue;
+        }
+        const auto& transceivers = temp_pc_->GetTransceivers();
+        for (auto& transceiver : transceivers) {
+          const auto& ttrack = transceiver->sender()->track();
+          if (ttrack != nullptr && ttrack->id() == track->id()) {
+            temp_pc_->RemoveTrack(transceiver->sender());
+            transceiver->Stop();
+            break;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Behind `unpublish_on_signaling_thread`, **default off** — this ships as a no-op until the flag is set.

#Fix
Instead of calling transceiver->sender() in worker thread, which will call signaling_thread in loop, we move the loop to signaling_thread to reduce the calls.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which thread runs PeerConnection unpublish (`RemoveTrack`/`Stop`) via blocking `Invoke` on the signaling thread. Default-off limits blast radius, but enabling it can affect teardown latency, deadlocks, and media-path correctness.
> 
> **Overview**
> Adds `ClientConfiguration::unpublish_on_signaling_thread` (**default false**) so `DrainPendingStreams` can walk transceivers and `RemoveTrack`/`Stop` inside a single `Invoke` on WebRTC’s signaling thread instead of marshaling every proxy call from the caller.
> 
> When the flag is off, unpublish behavior is unchanged. When on, each audio/video track is unpublished via one hop, with `[CONN-DIAG] drain_unpublish` logs (hit index, scanned count, trackless/stopped transceivers). `PeerConnectionDependencyFactory::SignalingThread()` is exposed to support that hop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa4232aa6889c1d5a406736c4d036bee78e8df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->