### PR TITLE
DO NOT MERGE: unpublish_on_signaling_thread default on + phase logging

### DIFF
--- a/talk/owt/sdk/base/peerconnectionchannel.h
+++ b/talk/owt/sdk/base/peerconnectionchannel.h
@@ -57,7 +57,7 @@ struct PeerConnectionChannelConfiguration
   bool encoded_video_frame_;
   /// Run the unpublish transceiver walk inside one Invoke on signaling_thread.
   /// See ClientConfiguration::unpublish_on_signaling_thread.
-  bool unpublish_on_signaling_thread = false;
+  bool unpublish_on_signaling_thread = true;
 };
 class PeerConnectionChannel : public webrtc::PeerConnectionObserver,
                               public webrtc::DataChannelObserver,

--- a/talk/owt/sdk/include/cpp/owt/base/clientconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/clientconfiguration.h
@@ -15,7 +15,7 @@ struct ClientConfiguration {
   ClientConfiguration()
        : candidate_network_policy(CandidateNetworkPolicy::kAll),
          continual_ice_gathering(true),
-         unpublish_on_signaling_thread(false) {}
+         unpublish_on_signaling_thread(true) {}
   /// List of ICE servers
   std::vector<IceServer> ice_servers;
   /**

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1314,51 +1314,60 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       // marshal instead: SynchronousMethodCall::Invoke calls the handler directly when
       // t->IsCurrent(), as does Thread::Send, so every proxy call inside the lambda
       // short-circuits. Behind a flag because it moves where the loop executes.
+      // Instrumented so the flag's effect is measurable: with it off every step of the
+      // walk is a marshal, with it on they are direct calls, and scanned/us_per_scan say
+      // which happened. Both media loops are counted, and the timers bracket the whole
+      // lambda, so the parts sum to total_ms -- an earlier version timed only the video
+      // loop and left the audio walk outside the window, which is why 58% of a 26s
+      // teardown was unattributed. transceivers= also shows the list still growing.
+      int n_transceivers = 0, scanned = 0;
+      int64_t get_us = 0, scan_us = 0, remove_us = 0, stop_us = 0;
+      int64_t audio_us = 0, video_us = 0;
+      size_t n_audio_tracks = 0, n_video_tracks = 0;
+      auto unpublish_one = [&](const rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>& track) {
+        const int64_t t_get = rtc::TimeMicros();
+        const auto& transceivers = temp_pc_->GetTransceivers();
+        get_us += rtc::TimeMicros() - t_get;
+        n_transceivers = static_cast<int>(transceivers.size());
+        for (auto& transceiver : transceivers) {
+          const int64_t t_s = rtc::TimeMicros();
+          const auto& ttrack = transceiver->sender()->track();
+          scan_us += rtc::TimeMicros() - t_s;
+          ++scanned;
+          if (ttrack != nullptr && ttrack->id() == track->id()) {
+            const int64_t t_r = rtc::TimeMicros();
+            temp_pc_->RemoveTrack(transceiver->sender());
+            const int64_t t_st = rtc::TimeMicros();
+            transceiver->Stop();
+            remove_us += t_st - t_r;
+            stop_us += rtc::TimeMicros() - t_st;
+            break;
+          }
+        }
+      };
       auto unpublish_all = [&] {
+        const int64_t t_all = rtc::TimeMicros();
+        const int64_t t_audio = t_all;
         for (const auto& track : media_stream->GetAudioTracks()) {
-          for (auto& transceiver : temp_pc_->GetTransceivers()) {
-            const auto& ttrack = transceiver->sender()->track();
-            if (ttrack != nullptr && ttrack->id() == track->id()) {
-              temp_pc_->RemoveTrack(transceiver->sender());
-              transceiver->Stop();
-              break;
-            }
-          }
+          ++n_audio_tracks;
+          unpublish_one(track);
         }
-        // Instrumented so the flag's effect is measurable: with it off every scan step
-        // is a marshal, with it on they are direct calls, and scanned/us_per_scan say
-        // which happened. transceivers= also shows the list still growing either way.
-        const int64_t t_vid = rtc::TimeMillis();
-        int n_transceivers = 0, scanned = 0;
-        int64_t get_us = 0, scan_us = 0, remove_us = 0, stop_us = 0;
-        const size_t n_video_tracks = media_stream->GetVideoTracks().size();
+        const int64_t t_video = rtc::TimeMicros();
+        audio_us = t_video - t_audio;
         for (const auto& track : media_stream->GetVideoTracks()) {
-          const int64_t t_get = rtc::TimeMicros();
-          const auto& transceivers = temp_pc_->GetTransceivers();
-          get_us += rtc::TimeMicros() - t_get;
-          n_transceivers = static_cast<int>(transceivers.size());
-          for (auto& transceiver : transceivers) {
-            const int64_t t_s = rtc::TimeMicros();
-            const auto& ttrack = transceiver->sender()->track();
-            scan_us += rtc::TimeMicros() - t_s;
-            ++scanned;
-            if (ttrack != nullptr && ttrack->id() == track->id()) {
-              const int64_t t_r = rtc::TimeMicros();
-              temp_pc_->RemoveTrack(transceiver->sender());
-              const int64_t t_st = rtc::TimeMicros();
-              transceiver->Stop();
-              remove_us += t_st - t_r;
-              stop_us += rtc::TimeMicros() - t_st;
-              break;
-            }
-          }
+          ++n_video_tracks;
+          unpublish_one(track);
         }
+        video_us = rtc::TimeMicros() - t_video;
         RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_unpublish peerid=" << remote_id_
                           << " on_signaling_thread="
                           << configuration_.unpublish_on_signaling_thread
+                          << " audio_tracks=" << n_audio_tracks
                           << " video_tracks=" << n_video_tracks
                           << " transceivers=" << n_transceivers
-                          << " video_loop_ms=" << (rtc::TimeMillis() - t_vid)
+                          << " total_ms=" << (rtc::TimeMicros() - t_all) / 1000
+                          << " audio_us=" << audio_us
+                          << " video_us=" << video_us
                           << " scanned=" << scanned
                           << " get_us=" << get_us
                           << " scan_us=" << scan_us

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1324,17 +1324,36 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       int64_t get_us = 0, scan_us = 0, remove_us = 0, stop_us = 0;
       int64_t audio_us = 0, video_us = 0;
       size_t n_audio_tracks = 0, n_video_tracks = 0;
+      // How much of the walk is corpses. hit_index is where the match sat
+      // (-1 = no match, which should not happen for a track being unpublished),
+      // dead_before_hit how many trackless transceivers were stepped over to
+      // reach it. If dead_before_hit tracks hit_index then accumulation is the
+      // whole cost and recycling stopped transceivers is the real fix; if it
+      // stays near zero the growth is live transceivers and the walk length is
+      // not the problem.
+      int hit_index = -1, dead_before_hit = 0;
       auto unpublish_one = [&](const rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>& track) {
         const int64_t t_get = rtc::TimeMicros();
         const auto& transceivers = temp_pc_->GetTransceivers();
         get_us += rtc::TimeMicros() - t_get;
         n_transceivers = static_cast<int>(transceivers.size());
+        int index = 0, dead_seen = 0;
         for (auto& transceiver : transceivers) {
           const int64_t t_s = rtc::TimeMicros();
           const auto& ttrack = transceiver->sender()->track();
           scan_us += rtc::TimeMicros() - t_s;
           ++scanned;
+          // A retired transceiver: RemoveTrack cleared its track, but it stays in
+          // the list because its m= line cannot leave an already-negotiated SDP.
+          // Read off the track already fetched above rather than stopped(), which
+          // is PROXY_CONSTMETHOD0 and would double the marshals when the flag is
+          // off. Counted, not skipped -- the walk itself is unchanged.
+          if (ttrack == nullptr) {
+            ++dead_seen;
+          }
           if (ttrack != nullptr && ttrack->id() == track->id()) {
+            hit_index = index;
+            dead_before_hit = dead_seen;
             const int64_t t_r = rtc::TimeMicros();
             temp_pc_->RemoveTrack(transceiver->sender());
             const int64_t t_st = rtc::TimeMicros();
@@ -1343,10 +1362,21 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
             stop_us += rtc::TimeMicros() - t_st;
             break;
           }
+          ++index;
         }
       };
       auto unpublish_all = [&] {
         const int64_t t_all = rtc::TimeMicros();
+        // Proof that the Invoke landed: if this is false the proxy calls below still
+        // marshal and the flag bought nothing.
+        rtc::Thread* sig_now = PeerConnectionDependencyFactory::Get() != nullptr
+                                   ? PeerConnectionDependencyFactory::Get()->SignalingThread()
+                                   : nullptr;
+        const bool on_sig = (sig_now != nullptr && sig_now->IsCurrent());
+        // One bare GetTransceivers, timed alone, as a single-call control.
+        const int64_t t_ctl = rtc::TimeMicros();
+        const size_t ctl_n = temp_pc_->GetTransceivers().size();
+        const int64_t ctl_us = rtc::TimeMicros() - t_ctl;
         const int64_t t_audio = t_all;
         for (const auto& track : media_stream->GetAudioTracks()) {
           ++n_audio_tracks;
@@ -1365,6 +1395,8 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                           << " audio_tracks=" << n_audio_tracks
                           << " video_tracks=" << n_video_tracks
                           << " transceivers=" << n_transceivers
+                          << " hit_index=" << hit_index
+                          << " dead_before_hit=" << dead_before_hit
                           << " total_ms=" << (rtc::TimeMicros() - t_all) / 1000
                           << " audio_us=" << audio_us
                           << " video_us=" << video_us
@@ -1373,7 +1405,10 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                           << " scan_us=" << scan_us
                           << " remove_us=" << remove_us
                           << " stop_us=" << stop_us
-                          << " us_per_scan=" << (scanned ? scan_us / scanned : 0);
+                          << " us_per_scan=" << (scanned ? scan_us / scanned : 0)
+                          << " on_sig_actual=" << on_sig
+                          << " ctl_gettransceivers_us=" << ctl_us
+                          << " ctl_n=" << ctl_n;
       };
       // Same singleton PeerConnectionChannel assigns to factory_, which is private in
       // the base class.

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -22,6 +22,7 @@
 #include "talk/owt/sdk/base/sysinfo.h"
 #include "talk/owt/sdk/p2p/p2ppeerconnectionchannel.h"
 #include "webrtc/rtc_base/logging.h"
+#include "webrtc/rtc_base/time_utils.h"
 #include "webrtc/api/task_queue/default_task_queue_factory.h"
 
 using namespace rtc;
@@ -1324,16 +1325,46 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
             }
           }
         }
+        // Instrumented so the flag's effect is measurable: with it off every scan step
+        // is a marshal, with it on they are direct calls, and scanned/us_per_scan say
+        // which happened. transceivers= also shows the list still growing either way.
+        const int64_t t_vid = rtc::TimeMillis();
+        int n_transceivers = 0, scanned = 0;
+        int64_t get_us = 0, scan_us = 0, remove_us = 0, stop_us = 0;
+        const size_t n_video_tracks = media_stream->GetVideoTracks().size();
         for (const auto& track : media_stream->GetVideoTracks()) {
-          for (auto& transceiver : temp_pc_->GetTransceivers()) {
+          const int64_t t_get = rtc::TimeMicros();
+          const auto& transceivers = temp_pc_->GetTransceivers();
+          get_us += rtc::TimeMicros() - t_get;
+          n_transceivers = static_cast<int>(transceivers.size());
+          for (auto& transceiver : transceivers) {
+            const int64_t t_s = rtc::TimeMicros();
             const auto& ttrack = transceiver->sender()->track();
+            scan_us += rtc::TimeMicros() - t_s;
+            ++scanned;
             if (ttrack != nullptr && ttrack->id() == track->id()) {
+              const int64_t t_r = rtc::TimeMicros();
               temp_pc_->RemoveTrack(transceiver->sender());
+              const int64_t t_st = rtc::TimeMicros();
               transceiver->Stop();
+              remove_us += t_st - t_r;
+              stop_us += rtc::TimeMicros() - t_st;
               break;
             }
           }
         }
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_unpublish peerid=" << remote_id_
+                          << " on_signaling_thread="
+                          << configuration_.unpublish_on_signaling_thread
+                          << " video_tracks=" << n_video_tracks
+                          << " transceivers=" << n_transceivers
+                          << " video_loop_ms=" << (rtc::TimeMillis() - t_vid)
+                          << " scanned=" << scanned
+                          << " get_us=" << get_us
+                          << " scan_us=" << scan_us
+                          << " remove_us=" << remove_us
+                          << " stop_us=" << stop_us
+                          << " us_per_scan=" << (scanned ? scan_us / scanned : 0);
       };
       // Same singleton PeerConnectionChannel assigns to factory_, which is private in
       // the base class.

--- a/talk/owt/sdk/p2p/p2ppublication.cc
+++ b/talk/owt/sdk/p2p/p2ppublication.cc
@@ -6,6 +6,7 @@
 #include "webrtc/rtc_base/critical_section.h"
 #include "webrtc/rtc_base/logging.h"
 #include "webrtc/rtc_base/task_queue.h"
+#include "webrtc/rtc_base/time_utils.h"
 #include "talk/owt/sdk/base/stringutils.h"
 #include "talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h"
 #include "talk/owt/sdk/include/cpp/owt/p2p/p2ppublication.h"
@@ -63,13 +64,28 @@ void P2PPublication::GetStats(
 void P2PPublication::Stop() {
   auto that = p2p_client_.lock();
   if (that == nullptr || ended_) {
+    // A no-op Stop() and a fast one are both stop_ms=0 to the caller, so say which.
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=stop_noop peerid=" << target_id_
+                      << " ended=" << ended_
+                      << " client_gone=" << (that == nullptr);
     return;
   } else {
+    // remove_stream on a live node attributes 100% of a hangup's cost to this call
+    // (185ms p50, 702ms max, every lock in the appliance path at 0-1ms). Split it.
+    const int64_t t0 = rtc::TimeMillis();
     that->Unpublish(target_id_, local_stream_, nullptr, nullptr);
+    const int64_t t1 = rtc::TimeMillis();
     ended_ = true;
     const std::lock_guard<std::mutex> lock(observer_mutex_);
+    const int64_t t2 = rtc::TimeMillis();
     for (auto its = observers_.begin(); its != observers_.end(); ++its)
       (*its).get().OnEnded();
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=stop_phases peerid=" << target_id_
+                      << " unpublish_ms=" << (t1 - t0)
+                      << " observer_lock_ms=" << (t2 - t1)
+                      << " on_ended_ms=" << (rtc::TimeMillis() - t2)
+                      << " observers=" << observers_.size()
+                      << " total_ms=" << (rtc::TimeMillis() - t0);
   }
 }
 void P2PPublication::AddObserver(PublicationObserver& observer) {


### PR DESCRIPTION
**Do not merge.** Test build for validating owt#PR1 on a node.

Two changes on top of that PR:

1. `unpublish_on_signaling_thread` defaults to **true** in both `ClientConfiguration` and `PeerConnectionChannelConfiguration`, so a node picks the new path up without a portal config change.
2. Phase logging on the teardown path, at `LS_ERROR` because the appliance runs OWT at `kError`.

```
event=stop_noop         ended= client_gone=
event=stop_phases       unpublish_ms= observer_lock_ms= on_ended_ms= observers=
event=unpublish_phases  streamid_ms= pubmap_lock_ms= queue_ms= drain_ms=
event=drain_unpublish   on_signaling_thread= video_tracks= transceivers=
                        scanned= get_us= scan_us= remove_us= stop_us= us_per_scan=
```

## What to read after deploying

| field | expected | why |
|---|---|---|
| `us_per_scan` | 1239–3325us → single-digit us | the whole claim: each scan step stops marshalling |
| `scanned` | **unchanged** | the loop is identical; only the thread differs. A drop means something else changed |
| `transceivers` | still growing | this fix does not address accumulation, only the cost of walking it |
| `video_loop_ms` | 400ms+ → single digits | at the same transceiver count |
| `hangup exec_ms` | 3,864 over 1s per 6h → ~0 | the outcome that matters |

Baseline on `impossiblefoods-redwoodcity-node2` before the fix: 445 ms loop, 131 scanned at 3,325 us each, 462 transceivers, 97.9% of the teardown in the scan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flips the default thread for unpublish (signaling thread vs worker) on a hot PeerConnection teardown path, plus noisy LS_ERROR logs. Intended as a temporary node test build, not production.
> 
> **Overview**
> **Do not merge.** Test-only change so a node can validate the unpublish-on-signaling-thread path without a portal config flip.
> 
> `unpublish_on_signaling_thread` now defaults to **true** in both `ClientConfiguration` and `PeerConnectionChannelConfiguration`.
> 
> Adds `[CONN-DIAG]` `LS_ERROR` phase logs on teardown: `stop_noop` / `stop_phases` on `P2PPublication::Stop`, and `drain_unpublish` with per-step timings (`us_per_scan`, `scanned`, `transceivers`, `hit_index`/`dead_before_hit`, `on_sig_actual`). The walk itself is unchanged; this is instrumentation to confirm marshals collapse to direct calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a5f93c1f3594da59fe7de59f62cb8dc5cc64d5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->