### PR TITLE
Skip pc_thread_ for the two factory create calls, behind a flag

### DIFF
--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -12,6 +12,7 @@ bool GlobalConfiguration::encoded_frame_ = false;
 bool GlobalConfiguration::dual_video_encoder_ = false;
 bool GlobalConfiguration::bwe_optimization_settings_enabled_ = false;
 bool GlobalConfiguration::network_thread_realtime_enabled_ = false;
+bool GlobalConfiguration::skip_pc_thread_for_factory_calls_enabled_ = false;
 std::unique_ptr<AudioFrameGeneratorInterface>
     GlobalConfiguration::audio_frame_generator_ = nullptr;
 std::unique_ptr<VideoDecoderInterface>

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -279,6 +279,12 @@ scoped_refptr<webrtc::MediaStreamInterface>
 PeerConnectionDependencyFactory::CreateLocalMediaStream(
     const std::string& label) {
   RTC_CHECK(pc_thread_);
+  // pc_factory_ is a proxy: calling it only marshals
+  // PeerConnectionFactory::CreateLocalMediaStream onto signaling_thread and
+  // does nothing else, so the pc_thread_ hop is a redundant second queue.
+  if (GlobalConfiguration::GetSkipPcThreadForFactoryCallsEnabled()) {
+    return pc_factory_->CreateLocalMediaStream(label);
+  }
   return pc_thread_->Invoke<scoped_refptr<webrtc::MediaStreamInterface>>(
       RTC_FROM_HERE,
       Bind(&PeerConnectionFactoryInterface::CreateLocalMediaStream,
@@ -288,6 +294,12 @@ scoped_refptr<VideoTrackInterface>
 PeerConnectionDependencyFactory::CreateLocalVideoTrack(
     const std::string& id,
     webrtc::VideoTrackSourceInterface* video_source) {
+  // Same as CreateLocalMediaStream: the proxy only marshals
+  // PeerConnectionFactory::CreateVideoTrack onto signaling_thread and does
+  // nothing else, so the pc_thread_ hop is a redundant second queue.
+  if (GlobalConfiguration::GetSkipPcThreadForFactoryCallsEnabled()) {
+    return pc_factory_->CreateVideoTrack(id, video_source);
+  }
   return pc_thread_
       ->Invoke<scoped_refptr<VideoTrackInterface>>(
           RTC_FROM_HERE, Bind(&PeerConnectionFactoryInterface::CreateVideoTrack,

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -105,6 +105,20 @@ class GlobalConfiguration {
     return network_thread_realtime_enabled_;
   }
   /**
+   @brief Call CreateLocalMediaStream/CreateLocalVideoTrack on the factory proxy
+   directly instead of first hopping to pc_thread_.
+   */
+  static void SetSkipPcThreadForFactoryCallsEnabled(bool enabled) {
+    skip_pc_thread_for_factory_calls_enabled_ = enabled;
+  }
+  /**
+   @brief This function gets whether the pc_thread_ hop is bypassed.
+   @return true or false.
+   */
+  static bool GetSkipPcThreadForFactoryCallsEnabled() {
+    return skip_pc_thread_for_factory_calls_enabled_;
+  }
+  /**
    @brief This function sets the audio input to be an instance of
    AudioFrameGeneratorInterface.
    @details When it is enabled, SDK will not capture audio from mic. This means
@@ -279,6 +293,7 @@ class GlobalConfiguration {
    * Default is false. If true, network_thread is promoted to SCHED_RR.
    */
   static bool network_thread_realtime_enabled_;
+  static bool skip_pc_thread_for_factory_calls_enabled_;
   static std::unique_ptr<AudioFrameGeneratorInterface> audio_frame_generator_;
   /**
    @brief This function returns flag indicating whether customized video decoder is enabled or not


### PR DESCRIPTION
CreateLocalMediaStream` and `CreateLocalVideoTrack` marshal into pc_thread_ which marshals into signalling_thread with no extra work. So removing extra hop to pc_thread_.

## Measurements

16-tile video wall, encoded passthrough path:

| | pc_thread_ hop (before) | direct proxy (after) |
|---|---|---|
| worst `requeststream` | 18031.8ms | **2598.9ms** |
| worst factory call | 17720.9ms | **323.1ms** |
| `pc_thread_` queue wait share | 93.2% | **0.0%** |
| `pc_thread_` queue depth (max) | 15 | 0 waiting |
| `stream_create` worst | 17870.8ms | 845.1ms |

`stream_create` was 98% of publish time before; it is no longer the dominant term.

## Why it is safe

- `pc_thread_` is only the Invoke target. It is never stored in the returned objects, whose proxies bind to `signaling_thread` inside `PeerConnectionFactory::CreateLocalMediaStream`.
- `MethodCall::Marshal` posts and waits on a plain `rtc::Event`, so any thread may call it, and it short-circuits when already on the target thread.
- The `RTC_DCHECK(signaling_thread_->IsCurrent())` inside the real implementations still passes -- DCHECKs are enabled in this build (`is_debug = true`) and did not fire across 520 publishes.
- `pc_thread_` is retained for factory construction and `CreatePeerConnection`, where no proxy exists yet.

## Rollout

Off by default. Opt-in per node via `skip_pc_thread_for_factory_calls`. Requires the appliance-side plumbing PR.

## Testing

Tested on stackmod, check no regressions



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebRTC thread marshaling for stream/track creation; mitigated by default-off flag and narrow scope, but incorrect threading assumptions could cause subtle races or DCHECK failures in other deployments.
> 
> **Overview**
> Adds an **opt-in** `GlobalConfiguration` flag (`skip_pc_thread_for_factory_calls`, default **off**) so `PeerConnectionDependencyFactory` can call `CreateLocalMediaStream` and `CreateLocalVideoTrack` on the `pc_factory_` proxy **directly**, instead of first serializing through `pc_thread_->Invoke`.
> 
> When enabled, this removes a redundant second queue in front of the factory proxy’s existing marshal to `signaling_thread`, which the PR ties to large reductions in worst-case stream-create latency under heavy multi-tile publish load. **`pc_thread_` is unchanged** for factory construction and `CreatePeerConnection`; only these two create helpers get the fast path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeefa3257ec51d3ae1334ac9aede63ac848d2571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->