### PR TITLE
Log DrainPendingStreams wall time

### DIFF
--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1204,6 +1204,8 @@ bool P2PPeerConnectionChannel::IsStale() {
 }
 void P2PPeerConnectionChannel::DrainPendingStreams() {
   RTC_LOG(LS_INFO) << "Draining pending stream";
+  const auto drain_t0 = std::chrono::steady_clock::now();
+  int64_t publish_loop_us = 0, unpublish_loop_us = 0;
   ChangeSessionState(kSessionStateConnecting);
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   // Move contents of pending vectors to a temporary vector so
@@ -1232,6 +1234,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
   }
   // Snapshot vectors have no contention, safe to call webrtc methods.
   if (temp_pc_) {
+    const auto publish_loop_t0 = std::chrono::steady_clock::now();
     // Snapshot vector has no thread contention, safe to call webrtc methods.
     for (auto it = publish_snapshot.begin(); it != publish_snapshot.end(); ++it) {
       std::shared_ptr<LocalStream> stream = *it;
@@ -1297,6 +1300,9 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       json_stream_info[kMessageDataKey] = stream_info;
       SendSignalingMessage(json_stream_info);
     }
+    publish_loop_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                          std::chrono::steady_clock::now() - publish_loop_t0).count();
+    const auto unpublish_loop_t0 = std::chrono::steady_clock::now();
     for (auto it = unpublish_snapshot.begin(); it != unpublish_snapshot.end(); ++it) {
       std::shared_ptr<LocalStream> stream = *it;
       scoped_refptr<webrtc::MediaStreamInterface> media_stream =
@@ -1394,7 +1400,18 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
         }
       }
     }
+    unpublish_loop_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                            std::chrono::steady_clock::now() - unpublish_loop_t0).count();
   }
+  // LS_ERROR so it survives the appliance's kError OWT log severity.
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_timing peerid=" << remote_id_
+                    << " publish_streams=" << publish_snapshot.size()
+                    << " unpublish_streams=" << unpublish_snapshot.size()
+                    << " publish_loop_us=" << publish_loop_us
+                    << " unpublish_loop_us=" << unpublish_loop_us
+                    << " total_us="
+                    << std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - drain_t0).count();
   publish_snapshot.clear();
   unpublish_snapshot.clear();
 }


### PR DESCRIPTION
Stacked on #65.

Adds `event=drain_timing` to `DrainPendingStreams`: stream counts plus the publish/unpublish loop split.

```
[CONN-DIAG] event=drain_timing peerid=<id> publish_streams=8 unpublish_streams=0 \
            publish_loop_us=2275100 unpublish_loop_us=0 total_us=2275140
```

## Why

A drain flushes every stream queued for a peer, so one `requeststream` can pay for 8-16 streams' worth of work. Without this the cost is invisible at the appliance layer -- it shows up as a slow request with no explanation, and deferred drains (`drained_inline=0`) have no parent request at all.

Pairs with the appliance-side `event=requeststream_timing` / `event=stream_create_timing` in AmbientAI/appliance#2780.

## Notes

- `LS_ERROR` because the appliance sets OWT severity to `kError`, which drops `LS_INFO`. Informational, not an error.
- Logs on every drain including empty ones (both counts 0), which are cheap and frequent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: adds logging and microsecond timers without changing publish/unpublish behavior. Slightly higher log volume on every drain at LS_ERROR severity.
> 
> **Overview**
> Adds **CONN-DIAG timing** around `DrainPendingStreams` so multi-stream drains are visible in appliance logs (paired with appliance `requeststream_timing` / `stream_create_timing`).
> 
> The function now measures wall time with `std::chrono::steady_clock` for the full drain, the publish snapshot loop (`AddTrack` + signaling), and the unpublish loop separately. Each drain emits one `event=drain_timing` line at **`LS_ERROR`** (same elevation pattern as other `[CONN-DIAG]` logs) with `peerid`, `publish_streams` / `unpublish_streams` counts, `publish_loop_us`, `unpublish_loop_us`, and `total_us`—including cheap empty drains (both counts zero).
> 
> A small brace fix keeps unpublish timing and the summary log outside the per-`temp_pc_` block so totals still run when there is no peer connection ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29c5f3957c2b39c0e9c5aac55499ddfb53436542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->