### PR TITLE
Time each step inside the drain loops

### DIFF
--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -232,10 +232,13 @@ class P2PClient final
   virtual void OnStreamAdded(
       std::shared_ptr<owt::base::RemoteStream> stream);
  private:
+  /// |stop_id| correlates the CONN-DIAG spans this teardown emits. Defaulted so
+  /// existing callers are unaffected; 0 means "not part of a traced Stop()".
   void Unpublish(const std::string& target_id,
                  std::shared_ptr<LocalStream> stream,
                  std::function<void()> on_success,
-                 std::function<void(std::unique_ptr<Exception>)> on_failure);
+                 std::function<void(std::unique_ptr<Exception>)> on_failure,
+                 uint64_t stop_id = 0);
   std::shared_ptr<P2PPeerConnectionChannel> GetPeerConnectionChannel(
       const std::string& target_id);
   bool IsPeerConnectionChannelCreated(const std::string& target_id);

--- a/talk/owt/sdk/p2p/p2pclient.cc
+++ b/talk/owt/sdk/p2p/p2pclient.cc
@@ -291,7 +291,8 @@ void P2PClient::Unpublish(
     const std::string& target_id,
     std::shared_ptr<LocalStream> stream,
     std::function<void()> on_success,
-    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+    std::function<void(std::unique_ptr<Exception>)> on_failure,
+    uint64_t stop_id) {
   if (!IsPeerConnectionChannelCreated(target_id)) {
     if (on_failure) {
       event_queue_->PostTask([on_failure] {
@@ -304,7 +305,7 @@ void P2PClient::Unpublish(
     return;
   }
   auto pcc = GetPeerConnectionChannel(target_id);
-  pcc->Unpublish(stream, on_success, on_failure);
+  pcc->Unpublish(stream, on_success, on_failure, stop_id);
 }
 bool P2PClient::IsPeerConnectionChannelCreated(const std::string& target_id) {
   const std::lock_guard<std::mutex> lock(pc_channels_mutex_);

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -989,7 +989,10 @@ void P2PPeerConnectionChannel::Unpublish(
     std::shared_ptr<LocalStream> stream,
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  const auto unpublish_t0 = std::chrono::steady_clock::now();
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
+  const auto getpcref_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                               std::chrono::steady_clock::now() - unpublish_t0).count();
   if (!temp_pc_) {
     RTC_LOG(LS_INFO) << "Peer connection closed, returning.";
     // Skip on_success callback because technically we did not unpublish anything.
@@ -1019,9 +1022,22 @@ void P2PPeerConnectionChannel::Unpublish(
   // }
   RTC_CHECK(stream->MediaStream());
   // Calling MediaStream->id() runs on signaling_thread, so must be outside locks.
+  // That makes it a cross-thread Invoke from a pool worker: timed, because it
+  // blocks for as long as the signaling thread takes to pick the task up.
+  const auto mid_t0 = std::chrono::steady_clock::now();
   std::string stream_id = stream->MediaStream()->id();
+  const auto mediastream_id_us =
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - mid_t0).count();
+  // trackid for joining to the appliance's remove_stream and to
+  // publication_stop_timing.
+  const std::string& unpublish_trackid = stream_id;
+  const auto pubmap_t0 = std::chrono::steady_clock::now();
+  int64_t pubmap_lock_us = 0;
   {
     std::lock_guard<std::mutex> lock(published_streams_mutex_);
+    pubmap_lock_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                         std::chrono::steady_clock::now() - pubmap_t0).count();
     auto it = published_streams_.find(stream_id);
     if (it == published_streams_.end()) {
       // if (on_failure) {
@@ -1039,14 +1055,36 @@ void P2PPeerConnectionChannel::Unpublish(
       published_streams_.erase(it);
     }
   }
+  const auto pending_t0 = std::chrono::steady_clock::now();
+  int64_t pending_lock_us = 0;
   {
     std::lock_guard<std::mutex> lock(pending_unpublish_streams_mutex_);
+    pending_lock_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                          std::chrono::steady_clock::now() - pending_t0).count();
     pending_unpublish_streams_.push_back(stream);
   }
   if (on_success) {
     on_success();
   }
+  // Everything above is the pre-drain cost that sits between the appliance's
+  // stop_ms and drain_timing. Logged before the drain so the two are separable
+  // even when the drain is the slow part.
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_predrain_timing peerid=" << remote_id_
+                    << " trackid=" << unpublish_trackid
+                    << " getpcref_us=" << getpcref_us
+                    << " mediastream_id_us=" << mediastream_id_us
+                    << " pubmap_lock_us=" << pubmap_lock_us
+                    << " pending_lock_us=" << pending_lock_us
+                    << " total_us="
+                    << std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - unpublish_t0).count();
+  const auto drain_call_t0 = std::chrono::steady_clock::now();
   DrainPendingStreams();
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_drain_call_timing peerid=" << remote_id_
+                    << " trackid=" << unpublish_trackid
+                    << " total_us="
+                    << std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - drain_call_t0).count();
 }
 void P2PPeerConnectionChannel::Stop(
     std::function<void()> on_success,
@@ -1331,6 +1369,9 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       const auto mediastream_us =
           std::chrono::duration_cast<std::chrono::microseconds>(
               std::chrono::steady_clock::now() - stream_t0).count();
+      // Same value the appliance logs as trackid on remove_stream: carried on
+      // every span below so a drain joins to the hangup that triggered it.
+      const std::string trackid = stream->Id();
       RTC_CHECK(temp_pc_);
       PeerConnectionDependencyFactory* dependency_factory =
           configuration_.unpublish_on_signaling_thread
@@ -1342,6 +1383,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       const bool hop = signaling_thread != nullptr && !signaling_thread->IsCurrent();
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_stream_setup drain_id=" << drain_id
                         << " peerid=" << remote_id_
+                        << " trackid=" << trackid
                         << " stream_idx=" << stream_idx
                         << " hop=" << hop
                         << " mediastream_us=" << mediastream_us
@@ -1424,6 +1466,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       auto log_unpublish = [&](const char* kind) {
         RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_unpublish drain_id=" << drain_id
                           << " peerid=" << remote_id_
+                          << " trackid=" << trackid
                           << " stream_idx=" << stream_idx
                           << " kind=" << kind
                           << " on_signaling_thread="
@@ -1460,6 +1503,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
           log_unpublish("audio");
           RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing drain_id=" << drain_id
                             << " peerid=" << remote_id_
+                            << " trackid=" << trackid
                             << " stream_idx=" << stream_idx
                             << " track_idx=" << track_idx
                             << " kind=audio"
@@ -1484,6 +1528,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       }
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_audio_loop_timing drain_id=" << drain_id
                         << " peerid=" << remote_id_
+                        << " trackid=" << trackid
                         << " stream_idx=" << stream_idx
                         << " tracks=" << audio_tracks.size()
                         << " fetch_us=" << audio_fetch_us
@@ -1511,6 +1556,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
           log_unpublish("video");
           RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing drain_id=" << drain_id
                             << " peerid=" << remote_id_
+                            << " trackid=" << trackid
                             << " stream_idx=" << stream_idx
                             << " track_idx=" << track_idx
                             << " kind=video"
@@ -1533,6 +1579,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
             transceiver->Stop();
             RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing drain_id=" << drain_id
                               << " peerid=" << remote_id_
+                              << " trackid=" << trackid
                               << " stream_idx=" << stream_idx
                               << " track_idx=" << track_idx
                               << " kind=video"
@@ -1552,6 +1599,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       }
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_video_loop_timing drain_id=" << drain_id
                         << " peerid=" << remote_id_
+                        << " trackid=" << trackid
                         << " stream_idx=" << stream_idx
                         << " tracks=" << video_tracks.size()
                         << " fetch_us=" << video_fetch_us
@@ -1561,6 +1609,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       // Whole per-stream cost: setup + both track loops.
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_stream_timing drain_id=" << drain_id
                         << " peerid=" << remote_id_
+                        << " trackid=" << trackid
                         << " stream_idx=" << stream_idx
                         << " audio_tracks=" << audio_tracks.size()
                         << " video_tracks=" << video_tracks.size()

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1204,6 +1204,8 @@ bool P2PPeerConnectionChannel::IsStale() {
 }
 void P2PPeerConnectionChannel::DrainPendingStreams() {
   RTC_LOG(LS_INFO) << "Draining pending stream";
+  const auto drain_t0 = std::chrono::steady_clock::now();
+  int64_t publish_loop_us = 0, unpublish_loop_us = 0;
   ChangeSessionState(kSessionStateConnecting);
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   // Move contents of pending vectors to a temporary vector so
@@ -1232,6 +1234,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
   }
   // Snapshot vectors have no contention, safe to call webrtc methods.
   if (temp_pc_) {
+    const auto publish_loop_t0 = std::chrono::steady_clock::now();
     // Snapshot vector has no thread contention, safe to call webrtc methods.
     for (auto it = publish_snapshot.begin(); it != publish_snapshot.end(); ++it) {
       std::shared_ptr<LocalStream> stream = *it;
@@ -1297,6 +1300,9 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       json_stream_info[kMessageDataKey] = stream_info;
       SendSignalingMessage(json_stream_info);
     }
+    publish_loop_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                          std::chrono::steady_clock::now() - publish_loop_t0).count();
+    const auto unpublish_loop_t0 = std::chrono::steady_clock::now();
     for (auto it = unpublish_snapshot.begin(); it != unpublish_snapshot.end(); ++it) {
       std::shared_ptr<LocalStream> stream = *it;
       scoped_refptr<webrtc::MediaStreamInterface> media_stream =
@@ -1394,7 +1400,18 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
         }
       }
     }
+    unpublish_loop_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                            std::chrono::steady_clock::now() - unpublish_loop_t0).count();
   }
+  // LS_ERROR so it survives the appliance's kError OWT log severity.
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_timing peerid=" << remote_id_
+                    << " publish_streams=" << publish_snapshot.size()
+                    << " unpublish_streams=" << unpublish_snapshot.size()
+                    << " publish_loop_us=" << publish_loop_us
+                    << " unpublish_loop_us=" << unpublish_loop_us
+                    << " total_us="
+                    << std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - drain_t0).count();
   publish_snapshot.clear();
   unpublish_snapshot.clear();
 }

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -988,7 +988,8 @@ void P2PPeerConnectionChannel::CleanLastPeerConnection() {
 void P2PPeerConnectionChannel::Unpublish(
     std::shared_ptr<LocalStream> stream,
     std::function<void()> on_success,
-    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+    std::function<void(std::unique_ptr<Exception>)> on_failure,
+    uint64_t stop_id) {
   const auto unpublish_t0 = std::chrono::steady_clock::now();
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
   const auto getpcref_us = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -1062,6 +1063,9 @@ void P2PPeerConnectionChannel::Unpublish(
     pending_lock_us = std::chrono::duration_cast<std::chrono::microseconds>(
                           std::chrono::steady_clock::now() - pending_t0).count();
     pending_unpublish_streams_.push_back(stream);
+    // The drain runs inline on this thread just below, so the id is picked up
+    // by that call. Guarded by the same mutex as the queue it describes.
+    pending_stop_id_ = stop_id;
   }
   if (on_success) {
     on_success();
@@ -1070,6 +1074,7 @@ void P2PPeerConnectionChannel::Unpublish(
   // stop_ms and drain_timing. Logged before the drain so the two are separable
   // even when the drain is the slow part.
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_predrain_timing peerid=" << remote_id_
+                    << " stop_id=" << stop_id
                     << " trackid=" << unpublish_trackid
                     << " getpcref_us=" << getpcref_us
                     << " mediastream_id_us=" << mediastream_id_us
@@ -1081,6 +1086,7 @@ void P2PPeerConnectionChannel::Unpublish(
   const auto drain_call_t0 = std::chrono::steady_clock::now();
   DrainPendingStreams();
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_drain_call_timing peerid=" << remote_id_
+                    << " stop_id=" << stop_id
                     << " trackid=" << unpublish_trackid
                     << " total_us="
                     << std::chrono::duration_cast<std::chrono::microseconds>(
@@ -1249,6 +1255,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
   // lines below join to one drain without needing timestamps (RTC_LOG has none).
   static std::atomic<uint64_t> drain_seq{0};
   const uint64_t drain_id = drain_seq.fetch_add(1, std::memory_order_relaxed);
+  uint64_t stop_id = 0;
   int64_t publish_loop_us = 0, unpublish_loop_us = 0;
   ChangeSessionState(kSessionStateConnecting);
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
@@ -1275,6 +1282,9 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       unpublish_snapshot.push_back(stream);
     }
     pending_unpublish_streams_.clear();
+    // Taken with the snapshot: identifies the Stop() whose streams these are.
+    stop_id = pending_stop_id_;
+    pending_stop_id_ = 0;
   }
   // Snapshot vectors have no contention, safe to call webrtc methods.
   if (temp_pc_) {
@@ -1355,6 +1365,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                           std::chrono::steady_clock::now() - publish_loop_t0).count();
     const auto unpublish_loop_t0 = std::chrono::steady_clock::now();
     RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_loop_enter drain_id=" << drain_id
+                      << " stop_id=" << stop_id
                       << " peerid=" << remote_id_
                       << " streams=" << unpublish_snapshot.size();
     int unpublish_stream_idx = 0;
@@ -1382,6 +1393,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                                           : nullptr;
       const bool hop = signaling_thread != nullptr && !signaling_thread->IsCurrent();
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_stream_setup drain_id=" << drain_id
+                        << " stop_id=" << stop_id
                         << " peerid=" << remote_id_
                         << " trackid=" << trackid
                         << " stream_idx=" << stream_idx
@@ -1465,6 +1477,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       // reduce interations of for loop.
       auto log_unpublish = [&](const char* kind) {
         RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_unpublish drain_id=" << drain_id
+                          << " stop_id=" << stop_id
                           << " peerid=" << remote_id_
                           << " trackid=" << trackid
                           << " stream_idx=" << stream_idx
@@ -1502,6 +1515,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                   std::chrono::steady_clock::now() - hop_t0).count();
           log_unpublish("audio");
           RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing drain_id=" << drain_id
+                            << " stop_id=" << stop_id
                             << " peerid=" << remote_id_
                             << " trackid=" << trackid
                             << " stream_idx=" << stream_idx
@@ -1527,6 +1541,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
         }
       }
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_audio_loop_timing drain_id=" << drain_id
+                        << " stop_id=" << stop_id
                         << " peerid=" << remote_id_
                         << " trackid=" << trackid
                         << " stream_idx=" << stream_idx
@@ -1555,6 +1570,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                   std::chrono::steady_clock::now() - hop_t0).count();
           log_unpublish("video");
           RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing drain_id=" << drain_id
+                            << " stop_id=" << stop_id
                             << " peerid=" << remote_id_
                             << " trackid=" << trackid
                             << " stream_idx=" << stream_idx
@@ -1578,6 +1594,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
             const auto stop_t0 = std::chrono::steady_clock::now();
             transceiver->Stop();
             RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing drain_id=" << drain_id
+                              << " stop_id=" << stop_id
                               << " peerid=" << remote_id_
                               << " trackid=" << trackid
                               << " stream_idx=" << stream_idx
@@ -1598,6 +1615,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
         }
       }
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_video_loop_timing drain_id=" << drain_id
+                        << " stop_id=" << stop_id
                         << " peerid=" << remote_id_
                         << " trackid=" << trackid
                         << " stream_idx=" << stream_idx
@@ -1608,6 +1626,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                                std::chrono::steady_clock::now() - video_loop_t0).count();
       // Whole per-stream cost: setup + both track loops.
       RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_stream_timing drain_id=" << drain_id
+                        << " stop_id=" << stop_id
                         << " peerid=" << remote_id_
                         << " trackid=" << trackid
                         << " stream_idx=" << stream_idx
@@ -1623,6 +1642,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
   }
   // LS_ERROR so it survives the appliance's kError OWT log severity.
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_timing drain_id=" << drain_id
+                    << " stop_id=" << stop_id
                     << " peerid=" << remote_id_
                     << " publish_streams=" << publish_snapshot.size()
                     << " unpublish_streams=" << unpublish_snapshot.size()

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -13,6 +13,7 @@
 // TODO: Fix at binary level — configure OWT to emit LS_INFO or lower so log
 // levels here can be set correctly (LS_INFO for lifecycle events, LS_WARNING
 // for non-critical issues, LS_ERROR only for genuine failures).
+#include <chrono>
 #include <thread>
 #include <vector>
 #include <iostream>
@@ -1283,7 +1284,14 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
         track_info[kTrackIdKey] = track->id();
         track_info[kTrackSourceKey] = video_track_source;
         track_sources.append(track_info);
+        // AddTrack marks negotiation needed, so it can run CreateOffer inline.
+        const auto add_track_t0 = std::chrono::steady_clock::now();
         temp_pc_->AddTrack(track, {stream_id});
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=add_track_timing peerid=" << remote_id_
+                          << " stream_id=" << stream_id
+                          << " total_us="
+                          << std::chrono::duration_cast<std::chrono::microseconds>(
+                                 std::chrono::steady_clock::now() - add_track_t0).count();
       }
       // The second signaling message of track sources to remote peer.
       Json::Value json_track_sources;
@@ -1320,6 +1328,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       size_t n_transceivers = 0;
       int scanned = 0, hit_index = -1;
       int trackless_before_hit = 0, stopped_before_hit = 0;
+      int64_t remove_track_us = 0, stop_us = 0;
 
       // Every step here is a signaling proxy call, so off-thread each one marshals.
       // Running unpublish_track() on signaling_thread makes the whole walk a single hop.
@@ -1330,6 +1339,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
             // than inheriting the previous track's hit.
             scanned = trackless_before_hit = stopped_before_hit = 0;
             hit_index = -1;
+            remove_track_us = stop_us = 0;
             const auto& transceivers = temp_pc_->GetTransceivers();
             n_transceivers = transceivers.size();
             int index = 0;
@@ -1343,8 +1353,14 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
               }
               if (ttrack != nullptr && ttrack->id() == track->id()) {
                 hit_index = index;
+                const auto remove_t0 = std::chrono::steady_clock::now();
                 temp_pc_->RemoveTrack(transceiver->sender());
+                const auto stop_t0 = std::chrono::steady_clock::now();
                 transceiver->Stop();
+                remove_track_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                      stop_t0 - remove_t0).count();
+                stop_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                              std::chrono::steady_clock::now() - stop_t0).count();
                 break;
               }
               ++index;
@@ -1364,7 +1380,9 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                           << " scanned=" << scanned
                           << " hit_index=" << hit_index
                           << " trackless_before_hit=" << trackless_before_hit
-                          << " stopped_before_hit=" << stopped_before_hit;
+                          << " stopped_before_hit=" << stopped_before_hit
+                          << " remove_track_us=" << remove_track_us
+                          << " stop_us=" << stop_us;
       };
 
       for (const auto& track : media_stream->GetAudioTracks()) {
@@ -1384,17 +1402,37 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
         }
       }
       for (const auto& track : media_stream->GetVideoTracks()) {
+        // Per track, both paths: the walk plus RemoveTrack and Stop, which mark
+        // negotiation needed and so can run CreateOffer inline.
+        const auto unpublish_one_t0 = std::chrono::steady_clock::now();
         if (hop) {
           signaling_thread->Invoke<void>(RTC_FROM_HERE, [&] { unpublish_track(track); });
           log_unpublish();
+          RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing peerid=" << remote_id_
+                            << " on_signaling_thread=1 total_us="
+                            << std::chrono::duration_cast<std::chrono::microseconds>(
+                                   std::chrono::steady_clock::now() - unpublish_one_t0).count();
           continue;
         }
         const auto& transceivers = temp_pc_->GetTransceivers();
         for (auto& transceiver : transceivers) {
           const auto& ttrack = transceiver->sender()->track();
           if (ttrack != nullptr && ttrack->id() == track->id()) {
+            const auto remove_t0 = std::chrono::steady_clock::now();
             temp_pc_->RemoveTrack(transceiver->sender());
+            const auto stop_t0 = std::chrono::steady_clock::now();
             transceiver->Stop();
+            RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing peerid=" << remote_id_
+                              << " on_signaling_thread=0 transceivers=" << transceivers.size()
+                              << " remove_track_us="
+                              << std::chrono::duration_cast<std::chrono::microseconds>(
+                                     stop_t0 - remove_t0).count()
+                              << " stop_us="
+                              << std::chrono::duration_cast<std::chrono::microseconds>(
+                                     std::chrono::steady_clock::now() - stop_t0).count()
+                              << " total_us="
+                              << std::chrono::duration_cast<std::chrono::microseconds>(
+                                     std::chrono::steady_clock::now() - unpublish_one_t0).count();
             break;
           }
         }

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -174,6 +174,7 @@ void P2PPeerConnectionChannel::ClearPendingStreams() {
   {
     std::lock_guard<std::mutex> lock(pending_unpublish_streams_mutex_);
     pending_unpublish_streams_.clear();
+    pending_unpublish_stop_ids_.clear();
   }
 }
 
@@ -1098,9 +1099,9 @@ void P2PPeerConnectionChannel::Unpublish(
     pending_lock_us = std::chrono::duration_cast<std::chrono::microseconds>(
                           std::chrono::steady_clock::now() - pending_t0).count();
     pending_unpublish_streams_.push_back(stream);
-    // The drain runs inline on this thread just below, so the id is picked up
-    // by that call. Guarded by the same mutex as the queue it describes.
-    pending_stop_id_ = stop_id;
+    // Kept in lockstep with the queue so a drain that takes N streams also takes
+    // their N ids.
+    pending_unpublish_stop_ids_.push_back(stop_id);
   }
   if (on_success) {
     on_success();
@@ -1290,16 +1291,30 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
   // lines below join to one drain without needing timestamps (RTC_LOG has none).
   static std::atomic<uint64_t> drain_seq{0};
   const uint64_t drain_id = drain_seq.fetch_add(1, std::memory_order_relaxed);
-  uint64_t stop_id = 0;
+  // One id per unpublished stream; drain-level events report the first, and
+  // per-stream events report their own.
+  std::vector<uint64_t> stop_id_snapshot;
   int64_t publish_loop_us = 0, unpublish_loop_us = 0;
+  // Entry region: everything before the loops. Two hangups were seen spending
+  // ~19.8s inside the drain with no per-stream span, which can only be here.
+  const auto entry_t0 = std::chrono::steady_clock::now();
   ChangeSessionState(kSessionStateConnecting);
+  const auto chgstate_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                               std::chrono::steady_clock::now() - entry_t0).count();
+  const auto pcref_t0 = std::chrono::steady_clock::now();
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
+  const auto pcref_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                            std::chrono::steady_clock::now() - pcref_t0).count();
   // Move contents of pending vectors to a temporary vector so
   // lock can be released before iterating over the streams.
   // First to publish the pending_publish_streams_ list.
   std::vector<std::shared_ptr<LocalStream>> publish_snapshot;
+  const auto publock_t0 = std::chrono::steady_clock::now();
+  int64_t publock_us = 0;
   {
     std::lock_guard<std::mutex> lock(pending_publish_streams_mutex_);
+    publock_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                     std::chrono::steady_clock::now() - publock_t0).count();
     for (auto it = pending_publish_streams_.begin();
          it != pending_publish_streams_.end(); ++it) {
       std::shared_ptr<LocalStream> stream = *it;
@@ -1309,18 +1324,34 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
   }
   // Then to unpublish the pending_unpublish_streams_ list.
   std::vector<std::shared_ptr<LocalStream>> unpublish_snapshot;
+  const auto unpublock_t0 = std::chrono::steady_clock::now();
+  int64_t unpublock_us = 0;
   {
     std::lock_guard<std::mutex> lock(pending_unpublish_streams_mutex_);
+    unpublock_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::steady_clock::now() - unpublock_t0).count();
     for (auto it = pending_unpublish_streams_.begin();
          it != pending_unpublish_streams_.end(); ++it) {
       std::shared_ptr<LocalStream> stream = *it;
       unpublish_snapshot.push_back(stream);
     }
     pending_unpublish_streams_.clear();
-    // Taken with the snapshot: identifies the Stop() whose streams these are.
-    stop_id = pending_stop_id_;
-    pending_stop_id_ = 0;
+    // Taken with the snapshot and indexed the same way, so each stream reports
+    // the Stop() that queued it rather than whichever one happened to be last.
+    stop_id_snapshot = pending_unpublish_stop_ids_;
+    pending_unpublish_stop_ids_.clear();
   }
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_entry_timing drain_id=" << drain_id
+                    << " peerid=" << remote_id_
+                    << " chgstate_us=" << chgstate_us
+                    << " getpcref_us=" << pcref_us
+                    << " publish_lock_us=" << publock_us
+                    << " unpublish_lock_us=" << unpublock_us
+                    << " pub=" << publish_snapshot.size()
+                    << " unpub=" << unpublish_snapshot.size()
+                    << " total_us="
+                    << std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - entry_t0).count();
   // Snapshot vectors have no contention, safe to call webrtc methods.
   if (temp_pc_) {
     const auto publish_loop_t0 = std::chrono::steady_clock::now();
@@ -1400,7 +1431,8 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                           std::chrono::steady_clock::now() - publish_loop_t0).count();
     const auto unpublish_loop_t0 = std::chrono::steady_clock::now();
     RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_loop_enter drain_id=" << drain_id
-                      << " stop_id=" << stop_id
+                      << " stop_id=" << (stop_id_snapshot.empty() ? 0 : stop_id_snapshot.front())
+                      << " stop_ids=" << stop_id_snapshot.size()
                       << " peerid=" << remote_id_
                       << " streams=" << unpublish_snapshot.size();
     int unpublish_stream_idx = 0;
@@ -1409,6 +1441,11 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       // SignalingThread() are both proxy calls that can marshal.
       const auto stream_t0 = std::chrono::steady_clock::now();
       const int stream_idx = unpublish_stream_idx++;
+      // This stream's own id, not the drain's: a drain can carry streams from
+      // several different Stop() calls.
+      const uint64_t stop_id =
+          (static_cast<size_t>(stream_idx) < stop_id_snapshot.size())
+              ? stop_id_snapshot[stream_idx] : 0;
       std::shared_ptr<LocalStream> stream = *it;
       scoped_refptr<webrtc::MediaStreamInterface> media_stream =
           stream->MediaStream();
@@ -1677,7 +1714,8 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
   }
   // LS_ERROR so it survives the appliance's kError OWT log severity.
   RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_timing drain_id=" << drain_id
-                    << " stop_id=" << stop_id
+                    << " stop_id=" << (stop_id_snapshot.empty() ? 0 : stop_id_snapshot.front())
+                    << " stop_ids=" << stop_id_snapshot.size()
                     << " peerid=" << remote_id_
                     << " publish_streams=" << publish_snapshot.size()
                     << " unpublish_streams=" << unpublish_snapshot.size()
@@ -1720,6 +1758,7 @@ void P2PPeerConnectionChannel::ClosePeerConnection() {
     {
       std::lock_guard<std::mutex> lock(pending_unpublish_streams_mutex_);
       pending_unpublish_streams_.clear();
+      pending_unpublish_stop_ids_.clear();
     }
     {
       std::lock_guard<std::mutex> lock(pending_publish_streams_mutex_);

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -899,7 +899,17 @@ void P2PPeerConnectionChannel::OnCreateSessionDescriptionSuccess(
           std::bind(
               &P2PPeerConnectionChannel::OnSetLocalSessionDescriptionFailure,
               this, std::placeholders::_1));
+  // SetLocalDescription chains onto libwebrtc's per-connection operations
+  // chain: it runs inline when the chain is empty, otherwise it only enqueues.
+  // sld_call_us is therefore how long the call itself blocked, and the callback
+  // reports the wall time to completion -- the two together locate the wait.
+  sld_t0_ = std::chrono::steady_clock::now();
+  sld_pending_.store(true, std::memory_order_relaxed);
   peer_connection_->SetLocalDescription(observer);
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=set_local_call_timing peerid=" << remote_id_
+                    << " sld_call_us="
+                    << std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - sld_t0_).count();
 }
 void P2PPeerConnectionChannel::OnCreateSessionDescriptionFailure(
     const std::string& error) {
@@ -908,8 +918,15 @@ void P2PPeerConnectionChannel::OnCreateSessionDescriptionFailure(
   Stop(nullptr, nullptr);
 }
 void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionSuccess() {
+  const auto cb_t0 = std::chrono::steady_clock::now();
+  const int64_t sld_total_us =
+      sld_pending_.exchange(false, std::memory_order_relaxed)
+          ? std::chrono::duration_cast<std::chrono::microseconds>(
+                cb_t0 - sld_t0_).count()
+          : -1;
   // LS_INFO (elevated to LS_ERROR — see file header note)
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=set_local_sdp_success peerid=" << remote_id_;
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=set_local_sdp_success peerid=" << remote_id_
+                    << " sld_total_us=" << sld_total_us;
   {
     std::lock_guard<std::mutex> lock(is_creating_offer_mutex_);
     is_creating_offer_ = false;
@@ -932,11 +949,29 @@ void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionSuccess() {
   json[kMessageTypeKey] = kChatSignal;
   json[kMessageDataKey] = signal;
   // The fourth signaling message of SDP to remote peer.
+  const auto send_t0 = std::chrono::steady_clock::now();
   SendSignalingMessage(json);
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=set_local_cb_timing peerid=" << remote_id_
+                    << " sdp_bytes=" << sdp.size()
+                    << " send_us="
+                    << std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - send_t0).count()
+                    << " cb_total_us="
+                    << std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - cb_t0).count();
 }
 void P2PPeerConnectionChannel::OnSetLocalSessionDescriptionFailure(
     const std::string& error) {
+  // Clear the flag here too: a SetLocalDescription that waits and then fails
+  // must not leave sld_pending_ set, or the next call's sld_total_us would be
+  // measured from this one's start.
+  const int64_t sld_total_us =
+      sld_pending_.exchange(false, std::memory_order_relaxed)
+          ? std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - sld_t0_).count()
+          : -1;
   RTC_LOG(LS_ERROR) << "[CONN-DIAG][ERROR] event=Set local sdp failed. peerid=" << remote_id_
+                   << " sld_total_us=" << sld_total_us
                    << " err=" << error;
   Stop(nullptr, nullptr);
 }

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -13,6 +13,7 @@
 // TODO: Fix at binary level — configure OWT to emit LS_INFO or lower so log
 // levels here can be set correctly (LS_INFO for lifecycle events, LS_WARNING
 // for non-critical issues, LS_ERROR only for genuine failures).
+#include <atomic>
 #include <chrono>
 #include <thread>
 #include <vector>
@@ -1206,6 +1207,10 @@ bool P2PPeerConnectionChannel::IsStale() {
 void P2PPeerConnectionChannel::DrainPendingStreams() {
   RTC_LOG(LS_INFO) << "Draining pending stream";
   const auto drain_t0 = std::chrono::steady_clock::now();
+  // Monotonic per-process id stamped on every line this drain emits, so the
+  // lines below join to one drain without needing timestamps (RTC_LOG has none).
+  static std::atomic<uint64_t> drain_seq{0};
+  const uint64_t drain_id = drain_seq.fetch_add(1, std::memory_order_relaxed);
   int64_t publish_loop_us = 0, unpublish_loop_us = 0;
   ChangeSessionState(kSessionStateConnecting);
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> temp_pc_ = GetPeerConnectionRef();
@@ -1311,10 +1316,21 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
     publish_loop_us = std::chrono::duration_cast<std::chrono::microseconds>(
                           std::chrono::steady_clock::now() - publish_loop_t0).count();
     const auto unpublish_loop_t0 = std::chrono::steady_clock::now();
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_loop_enter drain_id=" << drain_id
+                      << " peerid=" << remote_id_
+                      << " streams=" << unpublish_snapshot.size();
+    int unpublish_stream_idx = 0;
     for (auto it = unpublish_snapshot.begin(); it != unpublish_snapshot.end(); ++it) {
+      // Per stream: setup before any track work — MediaStream() and
+      // SignalingThread() are both proxy calls that can marshal.
+      const auto stream_t0 = std::chrono::steady_clock::now();
+      const int stream_idx = unpublish_stream_idx++;
       std::shared_ptr<LocalStream> stream = *it;
       scoped_refptr<webrtc::MediaStreamInterface> media_stream =
           stream->MediaStream();
+      const auto mediastream_us =
+          std::chrono::duration_cast<std::chrono::microseconds>(
+              std::chrono::steady_clock::now() - stream_t0).count();
       RTC_CHECK(temp_pc_);
       PeerConnectionDependencyFactory* dependency_factory =
           configuration_.unpublish_on_signaling_thread
@@ -1324,25 +1340,48 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                                           ? dependency_factory->SignalingThread()
                                           : nullptr;
       const bool hop = signaling_thread != nullptr && !signaling_thread->IsCurrent();
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_stream_setup drain_id=" << drain_id
+                        << " peerid=" << remote_id_
+                        << " stream_idx=" << stream_idx
+                        << " hop=" << hop
+                        << " mediastream_us=" << mediastream_us
+                        << " total_us="
+                        << std::chrono::duration_cast<std::chrono::microseconds>(
+                               std::chrono::steady_clock::now() - stream_t0).count();
 
       size_t n_transceivers = 0;
       int scanned = 0, hit_index = -1;
       int trackless_before_hit = 0, stopped_before_hit = 0;
       int64_t remove_track_us = 0, stop_us = 0;
+      // Measured, not derived. hop_t0 is stamped immediately before Invoke() and
+      // read as the first statement inside the lambda, so hop_wait_us is the
+      // queue wait itself rather than a parent-minus-children remainder.
+      std::chrono::steady_clock::time_point hop_t0;
+      int64_t hop_wait_us = 0, gettrans_us = 0, walk_us = 0, body_us = 0;
 
       // Every step here is a signaling proxy call, so off-thread each one marshals.
       // Running unpublish_track() on signaling_thread makes the whole walk a single hop.
       auto unpublish_track =
           [&](const rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>& track) {
             RTC_DCHECK(signaling_thread != nullptr && signaling_thread->IsCurrent());
+            // First statement: everything between hop_t0 and here is queue wait.
+            const auto body_t0 = std::chrono::steady_clock::now();
+            hop_wait_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                              body_t0 - hop_t0).count();
             // Per track, not cumulative: a miss must leave hit_index at -1 rather
             // than inheriting the previous track's hit.
             scanned = trackless_before_hit = stopped_before_hit = 0;
             hit_index = -1;
             remove_track_us = stop_us = 0;
+            const auto gettrans_t0 = std::chrono::steady_clock::now();
             const auto& transceivers = temp_pc_->GetTransceivers();
+            gettrans_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                              std::chrono::steady_clock::now() - gettrans_t0).count();
             n_transceivers = transceivers.size();
             int index = 0;
+            // Walk cost excluding RemoveTrack/Stop, which are timed on their own.
+            const auto walk_t0 = std::chrono::steady_clock::now();
+            walk_us = 0;
             for (auto& transceiver : transceivers) {
               const auto& ttrack = transceiver->sender()->track();
               if (ttrack == nullptr) {
@@ -1354,6 +1393,9 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
               if (ttrack != nullptr && ttrack->id() == track->id()) {
                 hit_index = index;
                 const auto remove_t0 = std::chrono::steady_clock::now();
+                // Walk ends here; the rest is RemoveTrack/Stop, timed below.
+                walk_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                              remove_t0 - walk_t0).count();
                 temp_pc_->RemoveTrack(transceiver->sender());
                 const auto stop_t0 = std::chrono::steady_clock::now();
                 transceiver->Stop();
@@ -1365,15 +1407,25 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
               }
               ++index;
             }
+            // No hit: the loop ran to completion, so the whole span was walking.
+            if (hit_index < 0) {
+              walk_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                            std::chrono::steady_clock::now() - walk_t0).count();
+            }
             scanned = index;
+            body_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                          std::chrono::steady_clock::now() - body_t0).count();
           };
 
       // LS_INFO (elevated to LS_ERROR — see file header note)
       // TODO (atharva): Check if failed and stopped transceivers are 
       // growing at high rate and should we clean them up as well to 
       // reduce interations of for loop.
-      auto log_unpublish = [&] {
-        RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_unpublish peerid=" << remote_id_
+      auto log_unpublish = [&](const char* kind) {
+        RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_unpublish drain_id=" << drain_id
+                          << " peerid=" << remote_id_
+                          << " stream_idx=" << stream_idx
+                          << " kind=" << kind
                           << " on_signaling_thread="
                           << configuration_.unpublish_on_signaling_thread
                           << " transceivers=" << n_transceivers
@@ -1381,14 +1433,43 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
                           << " hit_index=" << hit_index
                           << " trackless_before_hit=" << trackless_before_hit
                           << " stopped_before_hit=" << stopped_before_hit
+                          << " hop_wait_us=" << hop_wait_us
+                          << " gettrans_us=" << gettrans_us
+                          << " walk_us=" << walk_us
                           << " remove_track_us=" << remove_track_us
-                          << " stop_us=" << stop_us;
+                          << " stop_us=" << stop_us
+                          << " body_us=" << body_us;
       };
-
-      for (const auto& track : media_stream->GetAudioTracks()) {
+      // GetAudioTracks() is a signaling proxy call returning a copied vector,
+      // so it is timed apart from the per-track work that follows.
+      const auto audio_loop_t0 = std::chrono::steady_clock::now();
+      const auto audio_tracks = media_stream->GetAudioTracks();
+      const auto audio_fetch_us =
+          std::chrono::duration_cast<std::chrono::microseconds>(
+              std::chrono::steady_clock::now() - audio_loop_t0).count();
+      int audio_track_idx = 0;
+      for (const auto& track : audio_tracks) {
+        const auto audio_one_t0 = std::chrono::steady_clock::now();
+        const int track_idx = audio_track_idx++;
         if (hop) {
+          hop_t0 = std::chrono::steady_clock::now();
           signaling_thread->Invoke<void>(RTC_FROM_HERE, [&] { unpublish_track(track); });
-          log_unpublish();
+          const auto invoke_us =
+              std::chrono::duration_cast<std::chrono::microseconds>(
+                  std::chrono::steady_clock::now() - hop_t0).count();
+          log_unpublish("audio");
+          RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing drain_id=" << drain_id
+                            << " peerid=" << remote_id_
+                            << " stream_idx=" << stream_idx
+                            << " track_idx=" << track_idx
+                            << " kind=audio"
+                            << " on_signaling_thread=1"
+                            << " hop_wait_us=" << hop_wait_us
+                            << " body_us=" << body_us
+                            << " invoke_us=" << invoke_us
+                            << " total_us="
+                            << std::chrono::duration_cast<std::chrono::microseconds>(
+                                   std::chrono::steady_clock::now() - audio_one_t0).count();
           continue;
         }
         const auto& transceivers = temp_pc_->GetTransceivers();
@@ -1401,15 +1482,43 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
           }
         }
       }
-      for (const auto& track : media_stream->GetVideoTracks()) {
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_audio_loop_timing drain_id=" << drain_id
+                        << " peerid=" << remote_id_
+                        << " stream_idx=" << stream_idx
+                        << " tracks=" << audio_tracks.size()
+                        << " fetch_us=" << audio_fetch_us
+                        << " total_us="
+                        << std::chrono::duration_cast<std::chrono::microseconds>(
+                               std::chrono::steady_clock::now() - audio_loop_t0).count();
+
+      const auto video_loop_t0 = std::chrono::steady_clock::now();
+      const auto video_tracks = media_stream->GetVideoTracks();
+      const auto video_fetch_us =
+          std::chrono::duration_cast<std::chrono::microseconds>(
+              std::chrono::steady_clock::now() - video_loop_t0).count();
+      int video_track_idx = 0;
+      for (const auto& track : video_tracks) {
         // Per track, both paths: the walk plus RemoveTrack and Stop, which mark
         // negotiation needed and so can run CreateOffer inline.
         const auto unpublish_one_t0 = std::chrono::steady_clock::now();
+        const int track_idx = video_track_idx++;
         if (hop) {
+          hop_t0 = std::chrono::steady_clock::now();
           signaling_thread->Invoke<void>(RTC_FROM_HERE, [&] { unpublish_track(track); });
-          log_unpublish();
-          RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing peerid=" << remote_id_
-                            << " on_signaling_thread=1 total_us="
+          const auto invoke_us =
+              std::chrono::duration_cast<std::chrono::microseconds>(
+                  std::chrono::steady_clock::now() - hop_t0).count();
+          log_unpublish("video");
+          RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing drain_id=" << drain_id
+                            << " peerid=" << remote_id_
+                            << " stream_idx=" << stream_idx
+                            << " track_idx=" << track_idx
+                            << " kind=video"
+                            << " on_signaling_thread=1"
+                            << " hop_wait_us=" << hop_wait_us
+                            << " body_us=" << body_us
+                            << " invoke_us=" << invoke_us
+                            << " total_us="
                             << std::chrono::duration_cast<std::chrono::microseconds>(
                                    std::chrono::steady_clock::now() - unpublish_one_t0).count();
           continue;
@@ -1422,7 +1531,11 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
             temp_pc_->RemoveTrack(transceiver->sender());
             const auto stop_t0 = std::chrono::steady_clock::now();
             transceiver->Stop();
-            RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing peerid=" << remote_id_
+            RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_track_timing drain_id=" << drain_id
+                              << " peerid=" << remote_id_
+                              << " stream_idx=" << stream_idx
+                              << " track_idx=" << track_idx
+                              << " kind=video"
                               << " on_signaling_thread=0 transceivers=" << transceivers.size()
                               << " remove_track_us="
                               << std::chrono::duration_cast<std::chrono::microseconds>(
@@ -1437,12 +1550,31 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
           }
         }
       }
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_video_loop_timing drain_id=" << drain_id
+                        << " peerid=" << remote_id_
+                        << " stream_idx=" << stream_idx
+                        << " tracks=" << video_tracks.size()
+                        << " fetch_us=" << video_fetch_us
+                        << " total_us="
+                        << std::chrono::duration_cast<std::chrono::microseconds>(
+                               std::chrono::steady_clock::now() - video_loop_t0).count();
+      // Whole per-stream cost: setup + both track loops.
+      RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=unpublish_stream_timing drain_id=" << drain_id
+                        << " peerid=" << remote_id_
+                        << " stream_idx=" << stream_idx
+                        << " audio_tracks=" << audio_tracks.size()
+                        << " video_tracks=" << video_tracks.size()
+                        << " total_us="
+                        << std::chrono::duration_cast<std::chrono::microseconds>(
+                               std::chrono::steady_clock::now() - stream_t0).count();
     }
+
     unpublish_loop_us = std::chrono::duration_cast<std::chrono::microseconds>(
                             std::chrono::steady_clock::now() - unpublish_loop_t0).count();
   }
   // LS_ERROR so it survives the appliance's kError OWT log severity.
-  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_timing peerid=" << remote_id_
+  RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=drain_timing drain_id=" << drain_id
+                    << " peerid=" << remote_id_
                     << " publish_streams=" << publish_snapshot.size()
                     << " unpublish_streams=" << unpublish_snapshot.size()
                     << " publish_loop_us=" << publish_loop_us

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -207,9 +207,12 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   std::unordered_set<std::string> publishing_streams_;
   std::mutex pending_publish_streams_mutex_;
   std::mutex pending_unpublish_streams_mutex_;
-  // stop_id of the Stop() that queued the pending unpublishes; read with
-  // the snapshot in DrainPendingStreams. Guarded by the mutex above.
-  uint64_t pending_stop_id_ = 0;
+  // stop_id per queued unpublish, parallel to pending_unpublish_streams_ and
+  // guarded by the same mutex. A scalar does not work here: Unpublish pushes one
+  // stream and drains inline, so several Stop() calls can queue before a drain
+  // runs and consumes them together. A single slot keeps only the last id and
+  // every other drain reports 0.
+  std::vector<uint64_t> pending_unpublish_stop_ids_;
   // Stamped just before SetLocalDescription() and read in its success/failure
   // callback. sdp_created -> set_local_sdp_success reached 30s in production
   // with no span covering it: SetLocalDescription queues on libwebrtc's

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -74,7 +74,8 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   // Unpublish a local stream to remote user.
   void Unpublish(std::shared_ptr<LocalStream> stream,
                  std::function<void()> on_success,
-                 std::function<void(std::unique_ptr<Exception>)> on_failure);
+                 std::function<void(std::unique_ptr<Exception>)> on_failure,
+                 uint64_t stop_id = 0);
   // Send message to remote user.
   void Send(const std::string& message,
             std::function<void()> on_success,
@@ -205,6 +206,9 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   std::unordered_set<std::string> publishing_streams_;
   std::mutex pending_publish_streams_mutex_;
   std::mutex pending_unpublish_streams_mutex_;
+  // stop_id of the Stop() that queued the pending unpublishes; read with
+  // the snapshot in DrainPendingStreams. Guarded by the mutex above.
+  uint64_t pending_stop_id_ = 0;
   // Shared by |published_streams_| and |publishing_streams_|.
   std::mutex published_streams_mutex_;
   std::vector<P2PPeerConnectionChannelObserver*> observers_;

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
+#include <atomic>
 #include <chrono>
 #include "talk/owt/sdk/base/peerconnectiondependencyfactory.h"
 #include "talk/owt/sdk/base/peerconnectionchannel.h"
@@ -209,6 +210,14 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   // stop_id of the Stop() that queued the pending unpublishes; read with
   // the snapshot in DrainPendingStreams. Guarded by the mutex above.
   uint64_t pending_stop_id_ = 0;
+  // Stamped just before SetLocalDescription() and read in its success/failure
+  // callback. sdp_created -> set_local_sdp_success reached 30s in production
+  // with no span covering it: SetLocalDescription queues on libwebrtc's
+  // per-connection operations chain, so the call can return instantly while the
+  // observer fires much later. Timing the call and the callback separately says
+  // which of the two holds the time.
+  std::chrono::steady_clock::time_point sld_t0_;
+  std::atomic<bool> sld_pending_{false};
   // Shared by |published_streams_| and |publishing_streams_|.
   std::mutex published_streams_mutex_;
   std::vector<P2PPeerConnectionChannelObserver*> observers_;

--- a/talk/owt/sdk/p2p/p2ppublication.cc
+++ b/talk/owt/sdk/p2p/p2ppublication.cc
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include "webrtc/rtc_base/third_party/base64/base64.h"
 #include "webrtc/rtc_base/critical_section.h"
@@ -62,10 +63,13 @@ void P2PPublication::GetStats(
 
 /// Stop current publication.
 void P2PPublication::Stop() {
-  // trackid is local_stream_->Id(): the same value the appliance stores as the
-  // publication_map_ key and logs on remove_stream, so these spans join to the
-  // appliance-side stop_ms without threading a new argument through Stop(),
-  // which is a pure-virtual on the base Publication interface.
+  // stop_id is the join key for everything this teardown emits. trackid is not
+  // usable for that: the same stream is hung up more than once (retry, or a
+  // second hangup that finds nothing), so trackid collides across distinct
+  // Stop() calls and would merge them. stop_id is minted per call and is
+  // unique for the life of the process.
+  static std::atomic<uint64_t> stop_seq{0};
+  const uint64_t stop_id = stop_seq.fetch_add(1, std::memory_order_relaxed);
   const auto stop_t0 = std::chrono::steady_clock::now();
   const std::string trackid = local_stream_ ? local_stream_->Id() : std::string();
   auto that = p2p_client_.lock();
@@ -73,6 +77,7 @@ void P2PPublication::Stop() {
                            std::chrono::steady_clock::now() - stop_t0).count();
   if (that == nullptr || ended_) {
     RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=publication_stop_timing peerid=" << target_id_
+                      << " stop_id=" << stop_id
                       << " trackid=" << trackid
                       << " early_out=1 client_lock_us=" << lock_us
                       << " unpublish_us=0 onended_us=0 total_us="
@@ -84,7 +89,7 @@ void P2PPublication::Stop() {
     // drain_timing.total_us from this closes the gap between the appliance's
     // stop_ms and the drain.
     const auto unpub_t0 = std::chrono::steady_clock::now();
-    that->Unpublish(target_id_, local_stream_, nullptr, nullptr);
+    that->Unpublish(target_id_, local_stream_, nullptr, nullptr, stop_id);
     const auto unpublish_us = std::chrono::duration_cast<std::chrono::microseconds>(
                                   std::chrono::steady_clock::now() - unpub_t0).count();
     ended_ = true;
@@ -101,6 +106,7 @@ void P2PPublication::Stop() {
     const auto onended_us = std::chrono::duration_cast<std::chrono::microseconds>(
                                 std::chrono::steady_clock::now() - onended_t0).count();
     RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=publication_stop_timing peerid=" << target_id_
+                      << " stop_id=" << stop_id
                       << " trackid=" << trackid
                       << " early_out=0 client_lock_us=" << lock_us
                       << " unpublish_us=" << unpublish_us

--- a/talk/owt/sdk/p2p/p2ppublication.cc
+++ b/talk/owt/sdk/p2p/p2ppublication.cc
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <algorithm>
+#include <chrono>
 #include "webrtc/rtc_base/third_party/base64/base64.h"
 #include "webrtc/rtc_base/critical_section.h"
 #include "webrtc/rtc_base/logging.h"
@@ -61,15 +62,53 @@ void P2PPublication::GetStats(
 
 /// Stop current publication.
 void P2PPublication::Stop() {
+  // trackid is local_stream_->Id(): the same value the appliance stores as the
+  // publication_map_ key and logs on remove_stream, so these spans join to the
+  // appliance-side stop_ms without threading a new argument through Stop(),
+  // which is a pure-virtual on the base Publication interface.
+  const auto stop_t0 = std::chrono::steady_clock::now();
+  const std::string trackid = local_stream_ ? local_stream_->Id() : std::string();
   auto that = p2p_client_.lock();
+  const auto lock_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - stop_t0).count();
   if (that == nullptr || ended_) {
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=publication_stop_timing peerid=" << target_id_
+                      << " trackid=" << trackid
+                      << " early_out=1 client_lock_us=" << lock_us
+                      << " unpublish_us=0 onended_us=0 total_us="
+                      << std::chrono::duration_cast<std::chrono::microseconds>(
+                             std::chrono::steady_clock::now() - stop_t0).count();
     return;
   } else {
+    // The whole Unpublish call, which contains DrainPendingStreams. Subtracting
+    // drain_timing.total_us from this closes the gap between the appliance's
+    // stop_ms and the drain.
+    const auto unpub_t0 = std::chrono::steady_clock::now();
     that->Unpublish(target_id_, local_stream_, nullptr, nullptr);
+    const auto unpublish_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                  std::chrono::steady_clock::now() - unpub_t0).count();
     ended_ = true;
-    const std::lock_guard<std::mutex> lock(observer_mutex_);
-    for (auto its = observers_.begin(); its != observers_.end(); ++its)
-      (*its).get().OnEnded();
+    // Runs after the drain, still inside the appliance's stop_ms. Observer
+    // callbacks are arbitrary code, so they are timed rather than assumed cheap.
+    const auto onended_t0 = std::chrono::steady_clock::now();
+    size_t n_observers = 0;
+    {
+      const std::lock_guard<std::mutex> lock(observer_mutex_);
+      n_observers = observers_.size();
+      for (auto its = observers_.begin(); its != observers_.end(); ++its)
+        (*its).get().OnEnded();
+    }
+    const auto onended_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                std::chrono::steady_clock::now() - onended_t0).count();
+    RTC_LOG(LS_ERROR) << "[CONN-DIAG] event=publication_stop_timing peerid=" << target_id_
+                      << " trackid=" << trackid
+                      << " early_out=0 client_lock_us=" << lock_us
+                      << " unpublish_us=" << unpublish_us
+                      << " observers=" << n_observers
+                      << " onended_us=" << onended_us
+                      << " total_us="
+                      << std::chrono::duration_cast<std::chrono::microseconds>(
+                             std::chrono::steady_clock::now() - stop_t0).count();
   }
 }
 void P2PPublication::AddObserver(PublicationObserver& observer) {


### PR DESCRIPTION
Stacked on #66 (`feat/drain-timing`).

`drain_timing` from #66 gives the publish and unpublish loop totals. This attributes those totals to individual calls.

Both loops call methods that mark negotiation needed — `AddTrack` on publish, `RemoveTrack`/`Stop()` on unpublish — and `UpdateNegotiationNeeded` fires `OnRenegotiationNeeded`, which calls `CreateOffer()` synchronously. So the offer can be generated inline, and the cost lands on one call inside the loop rather than being spread across it.

| event | covers |
|---|---|
| `add_track_timing` | each `AddTrack` in the publish loop |
| `unpublish_track_timing` | each track in the unpublish loop, both flag paths, `remove_track_us` / `stop_us` split |
| `drain_unpublish` | gains `remove_track_us` / `stop_us` for the signaling-thread path |

The unpublish split covers both paths so the flag-on and flag-off costs are directly comparable, and on the flag-on path the split sits next to the existing walk counters (`scanned`, `hit_index`, `stopped_before_hit`) so walk length and call cost read together.

Logging only, no behaviour change. `p2ppeerconnectionchannel.o` compiles clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to logging and an optional parameter with a default; no production control-flow or media/signaling logic is altered.
> 
> **Overview**
> Adds **observability-only** `[CONN-DIAG]` instrumentation to break down slow publication stop and pending-stream drain paths, without changing WebRTC or signaling behavior.
> 
> **Correlation:** `P2PPublication::Stop()` mints a per-call **`stop_id`** and passes it through `P2PClient::Unpublish` → `P2PPeerConnectionChannel::Unpublish`. A parallel **`pending_unpublish_stop_ids_`** queue (cleared with pending unpublish lists) lets each drained stream log the `Stop()` that queued it. Optional **`drain_id`** groups all lines from one `DrainPendingStreams()` run.
> 
> **Where time is measured:** `publication_stop_timing` (client lock, full `Unpublish`, observer `OnEnded`); **`unpublish_predrain_timing`** / **`unpublish_drain_call_timing`** before vs inside drain; **`drain_entry_timing`** and **`drain_timing`** with publish/unpublish loop totals; per-step spans inside the loops (**`add_track_timing`**, **`unpublish_track_timing`**, audio/video loop and stream totals, richer **`drain_unpublish`** with `remove_track_us` / `stop_us` / signaling-thread hop wait); **`SetLocalDescription`** split into **`set_local_call_timing`**, **`sld_total_us`**, and **`set_local_cb_timing`** to separate enqueue vs callback delay.
> 
> Existing callers keep the default **`stop_id = 0`**. Diagnostics use **`LS_ERROR`** so lines survive the appliance’s OWT log filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1a6418d45bd813b1991317a3d3785b405e31df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->